### PR TITLE
Symmetry

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -118,6 +118,7 @@
         "label": "TSV of BAF dataframe",
         "help": "",
         "class": "file",
+        "optional": true,
         "patterns": ["*.tsv"]
       }
     ],

--- a/dxapp.json
+++ b/dxapp.json
@@ -80,6 +80,14 @@
         "class": "string",
         "optional": true,
         "help": "Genome build for plotting (eg. hg19, hg38, mm10, etc.). Default is hg19"
+      },
+      {
+        "name": "symmetry",
+        "label": "Symmetrical BAF plot",
+        "class": "boolean",
+        "default": true,
+        "optional": true,
+        "help": "Whether to plot symmetrical points on the BAF plot. Default is True."
       }
     ],
     "outputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -35,35 +35,35 @@
       {
         "name": "min_baf",
         "label": "Minimum BAF",
-        "class": "string",
+        "class": "float",
         "optional": true,
         "help": "Minimum BAF for BAF plot. Default is 0.04"
       },
       {
         "name": "max_baf",
         "label": "Maximum BAF",
-        "class": "string",
+        "class": "float",
         "optional": true,
         "help": "Maximum BAF for BAF plot. Default is 0.96"
       },
       {
         "name": "bin_size",
         "label": "Bin size",
-        "class": "string",
+        "class": "int",
         "optional": true,
         "help": "Bin size for plotting depth. Default is 1000"
       },
       {
         "name": "max_depth_plot",
         "label": "Maximum depth",
-        "class": "string",
+        "class": "int",
         "optional": true,
         "help": "Maximum depth for y-axis. Default is 750"
       },
       {
         "name": "min_depth",
         "label": "Minimum depth",
-        "class": "string",
+        "class": "int",
         "optional": true,
         "help": "Minimum depth for plotting. Default is 50"
       },
@@ -79,7 +79,7 @@
         "label": "Genome build",
         "class": "string",
         "optional": true,
-        "help": "Genome build for plotting (eg. hg19, hg38, mm10, etc.). Default is hg19"
+        "help": "Genome build for plotting (eg. hg19, hg38). Default is hg19"
       },
       {
         "name": "symmetry",

--- a/dxapp.json
+++ b/dxapp.json
@@ -119,7 +119,7 @@
         "help": "",
         "class": "file",
         "optional": true,
-        "patterns": ["*.tsv"]
+        "patterns": ["*.baf.tsv"]
       }
     ],
     "runSpec": {

--- a/dxapp.json
+++ b/dxapp.json
@@ -6,7 +6,7 @@
     "changeLog": [
         {
             "version": "2.0.0",
-            "date": "2025-10-01",
+            "date": "2025-04-15",
             "description": "Make app more flexible (remove hardcoded inputs). Improve plotting symmetry."
         }
     ],
@@ -37,35 +37,35 @@
         "label": "Minimum BAF",
         "class": "string",
         "optional": true,
-        "help": "Minimum BAF allowed"
+        "help": "Minimum BAF for BAF plot. Default is 0.04"
       },
       {
         "name": "max_baf",
         "label": "Maximum BAF",
         "class": "string",
         "optional": true,
-        "help": "Maximum BAF allowed"
+        "help": "Maximum BAF for BAF plot. Default is 0.96"
       },
       {
         "name": "bin_size",
         "label": "Bin size",
         "class": "string",
         "optional": true,
-        "help": "Bin size for plotting"
+        "help": "Bin size for plotting depth. Default is 1000"
       },
       {
         "name": "max_depth_plot",
         "label": "Maximum depth",
         "class": "string",
         "optional": true,
-        "help": "Maximum depth for y-axis"
+        "help": "Maximum depth for y-axis. Default is 750"
       },
       {
         "name": "min_depth",
         "label": "Minimum depth",
         "class": "string",
         "optional": true,
-        "help": "Minimum depth for plotting"
+        "help": "Minimum depth for plotting. Default is 50"
       },
       {
         "name": "chr_names",
@@ -79,7 +79,7 @@
         "label": "Genome build",
         "class": "string",
         "optional": true,
-        "help": "Genome build for plotting (eg. hg19, hg38, mm10, etc.)"
+        "help": "Genome build for plotting (eg. hg19, hg38, mm10, etc.). Default is hg19"
       }
     ],
     "outputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -36,6 +36,7 @@
         "name": "min_baf",
         "label": "Minimum BAF",
         "class": "float",
+        "default": 0.04,
         "optional": true,
         "help": "Minimum BAF for BAF plot. Default is 0.04"
       },
@@ -43,6 +44,7 @@
         "name": "max_baf",
         "label": "Maximum BAF",
         "class": "float",
+        "default": 0.96,
         "optional": true,
         "help": "Maximum BAF for BAF plot. Default is 0.96"
       },
@@ -50,6 +52,7 @@
         "name": "bin_size",
         "label": "Bin size",
         "class": "int",
+        "default": 1000,
         "optional": true,
         "help": "Bin size for plotting depth. Default is 1000"
       },
@@ -57,6 +60,7 @@
         "name": "max_depth_plot",
         "label": "Maximum depth",
         "class": "int",
+        "default": 750,
         "optional": true,
         "help": "Maximum depth for y-axis. Default is 750"
       },
@@ -64,6 +68,7 @@
         "name": "min_depth",
         "label": "Minimum depth",
         "class": "int",
+        "default": 50,
         "optional": true,
         "help": "Minimum depth for plotting. Default is 50"
       },
@@ -71,6 +76,7 @@
         "name": "chr_names",
         "label": "Chromosome names",
         "class": "string",
+        "default": "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y",
         "optional": true,
         "help": "Chromosome names used for axis labels"
       },
@@ -78,6 +84,7 @@
         "name": "genome",
         "label": "Genome build",
         "class": "string",
+        "default": "hg19",
         "optional": true,
         "help": "Genome build for plotting (eg. hg19, hg38). Default is hg19"
       },
@@ -88,6 +95,14 @@
         "default": true,
         "optional": true,
         "help": "Whether to plot symmetrical points on the BAF plot. Default is True."
+      },
+      {
+        "name": "output_tsv",
+        "label": "Output TSV",
+        "class": "boolean",
+        "default": false,
+        "optional": true,
+        "help": "Whether to output a TSV file of the BAF dataframe for testing purposes. Default is False."
       }
     ],
     "outputSpec": [
@@ -97,6 +112,13 @@
         "help": "",
         "class": "file",
         "patterns": ["*.png"]
+      },
+      {
+        "name": "tsv",
+        "label": "TSV of BAF dataframe",
+        "help": "",
+        "class": "file",
+        "patterns": ["*.tsv"]
       }
     ],
     "runSpec": {

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -107,7 +107,6 @@ read_to_df <- function(file) {
 
   # Add symmetrical values if required
   if (SYMMETRY) {
-    print("symmetry enabled")
     symmetric_df <- df
     symmetric_df$BAF <- 1 - df$BAF
     df <- rbind(df, symmetric_df)

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -69,7 +69,7 @@ MIN_DEPTH <- args$min_depth
 GENOME <- args$genome
 
 # Option to make BAF plot symmetrical
-SYMMETRY <- args$symmetry
+SYMMETRY <- toupper(args$symmetry)
 
 
 # List of functions

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -214,7 +214,7 @@ for (file in gvcf_files) {
 # make tsvs for testing if needed
 for (idx in 1:length(df_list)) {
   file_name <- paste0("baf_df_", idx, ".tsv")
-  write.table(df_list[idx], file=file_name, quote=FALSE, sep='\t', col.names = NA)
+  write.table(df_list[[idx]], file=file_name, quote=FALSE, sep='\t', col.names = NA)
 }
 
 # read bed files into binned dfs for depth plot

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -35,7 +35,7 @@ parser$add_argument("--max_depth_plot", type="integer", default=750,
     help = "Max depth to be shown on plot [default %(default)s]")
 parser$add_argument("--min_depth", type="integer", default=50,
     help="Minimum depth allowed [default %(default)s]")
-parser$add_argument("--chr_names", type="character", default=c(paste0(1:22), "X", "Y"),
+parser$add_argument("--chr_names", type="character", default="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y",
     help="Chromosome names [default %(default)s]")
 parser$add_argument("--genome", type="character", default="hg19",
     help="Genome build for plotKaryotype function [default %(default)s]")
@@ -60,7 +60,7 @@ BIN_SIZE <- args$bin_size
 MAX_DEPTH_PLOT <- args$max_depth_plot
 
 # Chromosome labels to feature in the plot X-axis
-CHR_NAMES <- args$chr_names
+CHR_NAMES <- strsplit(args$chr_names, ",")[[1]]
 
 # Minimum depth
 MIN_DEPTH <- args$min_depth
@@ -70,7 +70,6 @@ GENOME <- args$genome
 
 # Option to make BAF plot symmetrical
 SYMMETRY <- toupper(args$symmetry)
-
 
 
 # List of functions
@@ -212,10 +211,10 @@ for (file in gvcf_files) {
 }
 
 # make tsvs for testing if needed
-for (idx in 1:length(df_list)) {
-  file_name <- paste0("baf_df_", idx, ".tsv")
-  write.table(df_list[[idx]], file=file_name, quote=FALSE, sep='\t', col.names = NA)
-}
+mapply(function(df, file_name) {
+  base <- tools::file_path_sans_ext(tools::file_path_sans_ext(basename(file_name)))
+  write.table(df, file=paste0(base, ".baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
+}, df_list, gvcf_files)
 
 # read bed files into binned dfs for depth plot
 df_binned_list <- list()

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -72,6 +72,7 @@ GENOME <- args$genome
 SYMMETRY <- toupper(args$symmetry)
 
 
+
 # List of functions
 ##################################
 
@@ -106,6 +107,7 @@ read_to_df <- function(file) {
 
   # Add symmetrical values if required
   if (SYMMETRY) {
+    print("symmetry enabled")
     symmetric_df <- df
     symmetric_df$BAF <- 1 - df$BAF
     df <- rbind(df, symmetric_df)
@@ -120,9 +122,7 @@ read_to_df <- function(file) {
 # returns df_binned
 
 bin_df <- function(df, bin_size) {
-  head(df)
   polars_df <- as_polars_df(df[order(df$Chr, df$Position), ])
-  head(polars_df)
   rolling_df <- polars_df$rolling(
     index_column = "Position",
     group_by = "Chr",
@@ -210,6 +210,12 @@ df_list <- list()
 for (file in gvcf_files) {
   df_trimmed <- read_to_df(file)
   df_list[[length(df_list) + 1]] <- df_trimmed
+}
+
+# make tsvs for testing if needed
+for (idx in 1:length(df_list)) {
+  file_name <- paste0("baf_df_", idx, ".tsv")
+  write.table(df_list[idx], file=file_name, quote=FALSE, sep='\t', col.names = NA)
 }
 
 # read bed files into binned dfs for depth plot

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -96,6 +96,9 @@ read_to_df <- function(file) {
   df$RAF <- ifelse(df$Depth > 0, as.numeric(df$Ref_AD) / df$Depth, NA)
   df$BAF <- ifelse(df$Depth > 0, as.numeric(df$Alt_DP) / df$Depth, NA)
 
+  # Filter out low depth rows
+  df <- df[df$Depth >= MIN_DEPTH, ]
+
   return(df)
 }
 

--- a/src/script.sh
+++ b/src/script.sh
@@ -62,7 +62,7 @@ main() {
 
     if [ "$output_tsv" = true ]; then
         mkdir -p out/tsv
-        mv baf_df_*.tsv out/tsv
+        mv *.baf.tsv out/tsv
     fi
 
     dx-upload-all-outputs

--- a/src/script.sh
+++ b/src/script.sh
@@ -45,6 +45,10 @@ main() {
     if [ -n "$genome" ]; then
         options+="--genome $genome "
     fi
+    if [ -n "$symmetry" ]; then
+        options+="--symmetry $symmetry "
+    fi
+
 
     # Run R script with error handling
     if ! Rscript baf_depth_plotting.R $options; then
@@ -55,6 +59,11 @@ main() {
     # Deal with output
     mkdir -p out/baf_plot
     mv *.png out/baf_plot
+
+    if [ $output_tsv ]; then
+        mkdir -p out/tsv
+        mv baf_df_*.tsv out/tsv
+    fi
 
     dx-upload-all-outputs
 

--- a/src/script.sh
+++ b/src/script.sh
@@ -60,7 +60,7 @@ main() {
     mkdir -p out/baf_plot
     mv *.png out/baf_plot
 
-    if [ $output_tsv ]; then
+    if [ "$output_tsv" = true ]; then
         mkdir -p out/tsv
         mv baf_df_*.tsv out/tsv
     fi


### PR DESCRIPTION
Addresses #11 

BAF plot is now symmetrical around 0.5 and the points are limited to variants above the minimum depth threshold to reduce noise.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_plot_variant_baf/13)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added an optional setting to control symmetrical plotting of BAF values, now enabled by default.
	- Introduced optional TSV output of BAF data frames for testing purposes.
- **Improvements**
	- Enhanced input parameter types for greater accuracy and clarity.
	- Updated help descriptions for input parameters, including clearer defaults and refined examples.
	- Organised TSV output files into a dedicated folder for easier access.
- **Bug Fixes**
	- Corrected parsing of allele depth columns for consistent results.
	- Fixed a minor typo in plot annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->