### PR TITLE
Multiple vcf inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # eggd_plot_variant_baf
 
 ## What does this app do?
-Plots BAF and depth of variants from given VCF
+Plots BAF and depth of variants from given VCF/GVCF pair.
 
 
 ## What data are required for this app to run?
 **Required input files:**
-1. A VCF file (`.vcf`) - containing the merged small variants we want to plot.
-2. R packages (`.tar.gz`) - compressed tarball of R packages needed to generate plot.
+1. A VCF file (`.vcf`) - containing the VEP filtered variants for the BAF plot.
+2. A GVCF file (`.gvcf`) - containing the merged small variants for the depth plot.
+3. R packages (`.tar.gz`) - compressed tarball of R packages needed to generate plot.
 <br>
 
 **R Packages and Versions:**
@@ -16,6 +17,7 @@ Plots BAF and depth of variants from given VCF
 - `dplyr` (v1.1.4)
 - `karyoploteR` (v1.28.0)
 - `polars` (v0.22.0)
+- `argparse` (v2.2.5)
 
 **How to build the package**
 The package was built on Ubuntu 24.04 and R v4.3. Below are the steps:
@@ -42,11 +44,15 @@ This app outputs:
 ```
 dx run eggd_plot_variant_baf \
 -ivcf=file-xxxx \
+-igvcf=file-xxxx \
+-imax_depth=0.98 \
+-imin_depth=20 \
+-imin_baf=0 \
+-imax_baf=1
+-ibin_size=500
 -ipackages=file-xxxx  \
 --destination="output/eggd_plot_variant_baf"
 ```
 
 ## Notes
-The current version of the plotting has the following constraints:
-- plotting of variant depth is currently hard limited at DP<50, has a upper Y axis limit of 750 and plots the mean depth across 1000 consecutive variants
-- plotting of the BAF is hard limited at < 0.04 and > 0.96
+The current version must provide a value to the `bin_size` option as automatic scaling is not yet functional.

--- a/dxapp.json
+++ b/dxapp.json
@@ -141,7 +141,7 @@
       "file": "src/script.sh",
       "systemRequirements": {
         "*": {
-          "instanceType": "mem1_ssd2_v2_x4"
+          "instanceType": "mem3_ssd1_v2_x4"
         }
       },
       "assetDepends": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -126,7 +126,7 @@
         "name": "tsv",
         "label": "TSVs of BAF dataframes",
         "help": "",
-        "class": "array",
+        "class": "array:file",
         "optional": true,
         "patterns": ["*.baf.tsv"]
       }

--- a/dxapp.json
+++ b/dxapp.json
@@ -28,7 +28,7 @@
         "class": "file",
         "optional": false,
         "patterns": [
-          "*.sgenome.vcf$", "*.genome.vcf.gz$"
+          "*.genome.vcf$", "*.genome.vcf.gz$", "*.gvcf$", "*.gvcf.gz$"
         ],
         "help": "GVCF"
       },
@@ -124,9 +124,9 @@
       },
       {
         "name": "tsv",
-        "label": "TSV of BAF dataframe",
+        "label": "TSVs of BAF dataframes",
         "help": "",
-        "class": "file",
+        "class": "array",
         "optional": true,
         "patterns": ["*.baf.tsv"]
       }

--- a/dxapp.json
+++ b/dxapp.json
@@ -20,7 +20,17 @@
         "patterns": [
           "*.vcf$", "*.vcf.gz$"
         ],
-        "help": "VCF"
+        "help": "Filtered VCF from VEP"
+      },
+      {
+        "name": "gvcf",
+        "label": "GVCF",
+        "class": "file",
+        "optional": false,
+        "patterns": [
+          "*.sgenome.vcf$", "*.genome.vcf.gz$"
+        ],
+        "help": "GVCF"
       },
       {
         "name": "packages",

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -73,7 +73,7 @@ MIN_BAF <- args$min_baf
 MAX_BAF <- args$max_baf
 
 # Adjusts the Y-axis plot for mean_depth values
-MAX_DEPTH <- args$max_depth
+MAX_DEPTH_PCT <- args$max_depth
 
 # Chromosome labels to feature in the plot X-axis
 CHR_NAMES <- strsplit(args$chr_names, ",")[[1]]
@@ -201,12 +201,12 @@ get_plot <- function(snp.data.baf, snp.data.depth, file_name, max_depth, chr_nam
     cex = 0.5, r0 = 0.55, r1 = 1, col = "darkorange2"
   )
   # bottom graph
-  kpAxis(baf_depth_plot, r0 = 0, r1 = 0.45, ymax = max_depth, ymin = 0, tick.pos = c(0, 0.25, 0.5, 0.75, max_depth))
+  kpAxis(baf_depth_plot, r0 = 0, r1 = 0.45, ymax = max_depth, ymin = 0)
   kpPoints(baf_depth_plot,
     data = snp.data.depth, y = snp.data.depth$mean_depth,
     cex = 0.5, r0 = 0, r1 = 0.45, ymax = max_depth, ymin = 0, col = modified_depth
   )
-  kpAddMainTitle(baf_depth_plot, main = paste0(SAMPLE_NAME, " BAF vs Depth. Low DP filter (upper plot) = ", MIN_DEPTH, ". Max DP cut-off (lower plot) = ", MAX_DEPTH))
+  kpAddMainTitle(baf_depth_plot, main = paste0("BAF vs Depth.    Low DP filter (upper plot) = ", MIN_DEPTH, ". Max DP cut-off percentile (lower plot) = ", MAX_DEPTH_PCT*100, "%"))
   kpAddChromosomeSeparators(baf_depth_plot, col = "darkgray", lty = 3, data.panel = "all")
 
   dev.off()
@@ -222,7 +222,7 @@ df_vcf <- read_to_df(VCF_FILE)
 df_gvcf <- read_to_df(GVCF_FILE)
 
 # get quantiles for plotting limits
-MAX_DEPTH <- quantile(df_vcf$Depth, probs = MAX_DEPTH, names = FALSE)
+MAX_DEPTH <- round(quantile(df_gvcf$Depth, probs = MAX_DEPTH_PCT, names = FALSE), digits = 0)
 
 # Filter out low depth rows
 df_filtered <- df_vcf[df_vcf$Depth >= MIN_DEPTH, ]

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -227,18 +227,20 @@ MAX_DEPTH <- round(quantile(df_gvcf$Depth, probs = MAX_DEPTH_PCT, names = FALSE)
 # Filter out low depth rows
 df_filtered <- df_vcf[df_vcf$Depth >= MIN_DEPTH, ]
 
-# make tsvs for testing if needed
-base <- tools::file_path_sans_ext(tools::file_path_sans_ext(basename(VCF_FILE)))
-write.table(df_filtered, file=paste0(base, ".baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
-
 # dynamic bin size choice
 BIN_SIZE <- ifelse(
   exists("BIN_SIZE"), BIN_SIZE,
   ifelse(length(df_gvcf$Depth)/2000 >= 1, round(length(df_gvcf$Depth)/2000), 1)
 )
 
-# read bed file into binned df for depth plot
+# aggregate gvcf df into binned df for depth plot
 df_binned <- bin_df(df_gvcf, BIN_SIZE)
+
+# make tsvs for testing if needed
+write.table(df_vcf, file=paste0(SAMPLE_NAME, ".vcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
+write.table(df_filtered, file=paste0(SAMPLE_NAME, ".filtered.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
+write.table(df_gvcf, file=paste0(SAMPLE_NAME, ".gvcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
+write.table(df_binned, file=paste0(SAMPLE_NAME, ".binned.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
 
 # convert dfs for baf plotting into snp.data for karyoploter
 snp.data.baf <- get_snp_data_BAF(df_filtered)

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -55,6 +55,12 @@ if (args$max_depth < 0 || args$max_depth > 1) {
   stop("max_depth must be a percentile value between 0 and 1")
 }
 
+# get sample name & check they're the same for the two inputs
+SAMPLE_NAME <- str_split_1(sub("\\.vcf\\.tsv$", "", basename(args$vcf)), "_")[1]
+if (SAMPLE_NAME != str_split_1(sub("\\.gvcf\\.tsv$", "", basename(args$gvcf)), "_")[1]) {
+  stop("Sample names in VCF and GVCF files do not match")
+}
+
 # Configurables
 ##################
 
@@ -174,7 +180,7 @@ get_snp_data_Depth <- function(df) {
 # returns plot
 
 get_plot <- function(snp.data.baf, snp.data.depth, file_name, max_depth, chr_names, min_baf, max_baf, genome_build) {
-  file_name_png <- paste0(sub(".tsv", "", file_name), ".png")
+  file_name_png <- paste0(SAMPLE_NAME, ".baf.png")
   png(file_name_png, width = 15, height = 5, units = "in", res = 600)
   plot_parameters <- getDefaultPlotParams(plot.type = 4)
   plot_parameters$data1inmargin <- 2
@@ -195,12 +201,12 @@ get_plot <- function(snp.data.baf, snp.data.depth, file_name, max_depth, chr_nam
     cex = 0.5, r0 = 0.55, r1 = 1, col = "darkorange2"
   )
   # bottom graph
-  kpAxis(baf_depth_plot, r0 = 0, r1 = 0.45, ymax = max_depth, ymin = 0)
+  kpAxis(baf_depth_plot, r0 = 0, r1 = 0.45, ymax = max_depth, ymin = 0, tick.pos = c(0, 0.25, 0.5, 0.75, max_depth))
   kpPoints(baf_depth_plot,
     data = snp.data.depth, y = snp.data.depth$mean_depth,
     cex = 0.5, r0 = 0, r1 = 0.45, ymax = max_depth, ymin = 0, col = modified_depth
   )
-  kpAddMainTitle(baf_depth_plot, main = "BAF vs Depth")
+  kpAddMainTitle(baf_depth_plot, main = paste0(SAMPLE_NAME, " BAF vs Depth. Low DP filter (upper plot) = ", MIN_DEPTH, ". Max DP cut-off (lower plot) = ", MAX_DEPTH))
   kpAddChromosomeSeparators(baf_depth_plot, col = "darkgray", lty = 3, data.panel = "all")
 
   dev.off()
@@ -241,5 +247,5 @@ snp.data.baf <- get_snp_data_BAF(df_filtered)
 snp.data.depth <- get_snp_data_Depth(df_binned)
 
 # generate plots and save them
-get_plot(snp.data.baf, snp.data.depth, VCF_FILE, MAX_DEPTH, CHR_NAMES, MIN_BAF, MAX_BAF, GENOME)
+get_plot(snp.data.baf, snp.data.depth, SAMPLE_NAME, MAX_DEPTH, CHR_NAMES, MIN_BAF, MAX_BAF, GENOME)
 

--- a/src/script.sh
+++ b/src/script.sh
@@ -52,7 +52,7 @@ main() {
 
 
     # Run R script with error handling
-    if ! Rscript baf_depth_plotting.R --vcf "$vcf_prefix.vcf.tsv" "$gvcf_prefix.gvcf.tsv" $options; then
+    if ! Rscript baf_depth_plotting.R --vcf "$vcf_prefix.vcf.tsv" --gvcf "$gvcf_prefix.gvcf.tsv" $options; then
     echo "Error: BAF plotting failed with exit code $?" >&2
     exit 1
     fi

--- a/src/script.sh
+++ b/src/script.sh
@@ -21,6 +21,7 @@ main() {
     echo "R_LIBS_USER=~/R/library" >> ~/.Renviron
 
     bcftools query -f '%CHROM\t%POS\t%INFO/DP\t[ %AD]\n' $vcf_path -o "$vcf_prefix.vcf.tsv"
+    bcftools query -f '%CHROM\t%POS\t%INFO/DP\t[ %AD]\n' $gvcf_path -o "$gvcf_prefix.gvcf.tsv"
 
     # construct optional argument string
     options=""
@@ -51,7 +52,7 @@ main() {
 
 
     # Run R script with error handling
-    if ! Rscript baf_depth_plotting.R --vcf "$vcf_prefix.vcf.tsv" $options; then
+    if ! Rscript baf_depth_plotting.R --vcf "$vcf_prefix.vcf.tsv" "$gvcf_prefix.gvcf.tsv" $options; then
     echo "Error: BAF plotting failed with exit code $?" >&2
     exit 1
     fi


### PR DESCRIPTION
App now takes both vep vcf & gvcf
 - baf plot (top) made with vep vcf
 - depth plot (bottom) made with gvcf

Default instance now bigger to deal with gvcf

Plot titles & labels more informative

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_plot_variant_baf/17)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for a new required GVCF input, allowing users to provide GVCF files for analysis.
- **Improvements**
	- Updated help text for the VCF input to clarify it should be a filtered VCF from VEP.
	- Enhanced plotting and analysis by using GVCF data for depth calculations and binning.
	- Output files and plots now consistently use the sample name derived from input files.
	- Expanded command-line options and updated documentation to reflect new inputs and parameters.
- **Other**
	- Changed system requirements to use a different instance type for analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->