### PR TITLE
fix double count on gvcf

### DIFF
--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -98,7 +98,7 @@ SYMMETRY <- toupper(args$symmetry)
 # @parameter file
 # returns df
 
-read_to_df <- function(file) {
+read_to_df <- function(file, sym) {
   if (!file.exists(file)) {
     stop("File not found: ", file)
   }
@@ -121,7 +121,7 @@ read_to_df <- function(file) {
   df$BAF <- ifelse(df$Depth > 0, as.numeric(df$Alt_AD) / df$Depth, NA)
 
   # Add symmetrical values if required
-  if (SYMMETRY) {
+  if (sym == TRUE) {
     symmetric_df <- df
     symmetric_df$BAF <- 1 - df$BAF
     df <- rbind(df, symmetric_df)
@@ -226,10 +226,10 @@ get_plot <- function(snp.data.baf, snp.data.depth, file_name, max_depth, chr_nam
 ####################
 
 # read tsv file into df for BAF plot
-df_vcf <- read_to_df(VCF_FILE)
+df_vcf <- read_to_df(VCF_FILE, TRUE)
 
 # read tsv file into df for DEPTH plot
-df_gvcf <- read_to_df(GVCF_FILE)
+df_gvcf <- read_to_df(GVCF_FILE, FALSE)
 
 # get quantiles for plotting limits
 MAX_DEPTH <- round(quantile(df_gvcf$Depth, probs = MAX_DEPTH_PCT, names = FALSE), digits = 0)

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -226,7 +226,7 @@ get_plot <- function(snp.data.baf, snp.data.depth, file_name, max_depth, chr_nam
 ####################
 
 # read tsv file into df for BAF plot
-df_vcf <- read_to_df(VCF_FILE, TRUE)
+df_vcf <- read_to_df(VCF_FILE, SYMMETRY)
 
 # read tsv file into df for DEPTH plot
 df_gvcf <- read_to_df(GVCF_FILE, FALSE)


### PR DESCRIPTION
Added boolean second argument to read_to_df() to avoid doubling the gvcf unnecessarily

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_plot_variant_baf/19)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved control of symmetrical BAF value handling by making symmetry behaviour explicit per file, removing reliance on a global setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->