### PR TITLE
Update to enable eggd_plot_variant_baf to work for DIAS

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -118,7 +118,23 @@
         "default": false,
         "optional": true,
         "help": "Whether to output a TSV file of the BAF dataframe for testing purposes. Default is False."
-      }
+      }, 
+      {
+      "name": "vcf_index",
+      "label": "VCF Index (optional)",
+      "class": "file",
+      "optional": true,
+      "patterns": ["*.tbi$", "*.csi$"],
+      "help": "Optional index for the VCF. If provided, region (-r) filtering will be applied on chr_names."
+      },
+      {
+      "name": "gvcf_index",
+      "label": "GVCF Index (optional)",
+      "class": "file",
+      "optional": true,
+      "patterns": ["*.tbi$", "*.csi$"],
+      "help": "Optional index for the gVCF. If provided, region (-r) filtering will be applied on chr_names."
+     }
     ],
     "outputSpec": [
       {

--- a/src/script.sh
+++ b/src/script.sh
@@ -19,9 +19,11 @@ main() {
 
     tar -xzf $packages_path
     echo "R_LIBS_USER=~/R/library" >> ~/.Renviron
+    bcftools index "$vcf_path"
+    bcftools index "$gvcf_path"
 
-    bcftools query -f '%CHROM\t%POS\t%INFO/DP\t[ %AD]\n' $vcf_path -o "$vcf_prefix.vcf.tsv"
-    bcftools query -f '%CHROM\t%POS\t%INFO/DP\t[ %AD]\n' $gvcf_path -o "$gvcf_prefix.gvcf.tsv"
+    bcftools query -r "$chr_names" -f '%CHROM\t%POS\t%INFO/DP\t[ %AD]\n' $vcf_path -o "$vcf_prefix.vcf.tsv"
+    bcftools query -r "$chr_names" -f '%CHROM\t%POS[\t%DP]\n' "$gvcf_path" -o "$gvcf_prefix.gvcf.tsv"
 
     # construct optional argument string
     options=""

--- a/src/script.sh
+++ b/src/script.sh
@@ -19,11 +19,23 @@ main() {
 
     tar -xzf $packages_path
     echo "R_LIBS_USER=~/R/library" >> ~/.Renviron
-    bcftools index "$vcf_path"
-    bcftools index "$gvcf_path"
 
-    bcftools query -r "$chr_names" -f '%CHROM\t%POS\t%INFO/DP\t[ %AD]\n' $vcf_path -o "$vcf_prefix.vcf.tsv"
-    bcftools query -r "$chr_names" -f '%CHROM\t%POS[\t%DP]\n' "$gvcf_path" -o "$gvcf_prefix.gvcf.tsv"
+
+    # Detect if we should apply -r based on index inputs
+    vcf_region_arg=""
+    gvcf_region_arg=""
+
+    if [[ -n "${vcf_index_path:-}" ]]; then
+    vcf_region_arg="-r $chr_names"
+    fi
+
+    if [[ -n "${gvcf_index_path:-}" ]]; then
+    gvcf_region_arg="-r $chr_names"
+    fi
+
+
+    bcftools query $vcf_region_arg -f '%CHROM\t%POS\t%INFO/DP\t[ %AD]\n' $vcf_path -o "$vcf_prefix.vcf.tsv"
+    bcftools query $gvcf_region_arg -f '%CHROM\t%POS[\t%DP]\n' "$gvcf_path" -o "$gvcf_prefix.gvcf.tsv"
 
     # construct optional argument string
     options=""


### PR DESCRIPTION
Updates:
gVCF is not queried for AD in the script.sh, and in the read_to_df function only **"CHROM, POS, DP"** are required from the gVCF tsv.
Both VCF and gVCF are filtered by **chr_names** if the optional arguments `vcf_index` and `gvcf_index` are provided. This can be done with DIAS and TSO500 would would run as is without any changed needed.

Runs successfully for DIAS and for TSO500:

- [DIAS](https://platform.dnanexus.com/panx/projects/J26G5X04VVXfFpYJk639YBQP/monitor/job/J2F3zj04VVXy7zXKV8KyyyZp)
-[TSO500](https://platform.dnanexus.com/panx/projects/J26G5X04VVXfFpYJk639YBQP/monitor/job/J2F41Jj4VVXxp0JXx2X2zKzV)