### PR TITLE
Bed filtering branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,35 @@
 # eggd_plot_variant_baf
 
 ## What does this app do?
-Plots BAF and depth of variants from given VCF/GVCF pair.
+Plots BAF and depth of variants from given VCF/GVCF pair. The BAF plot is the top panel and the Depth plot is the bottom panel.
 
 
 ## What data are required for this app to run?
 **Required input files:**
-1. A VCF file (`.vcf`) - containing the VEP filtered variants for the BAF plot.
-2. A GVCF file (`.gvcf`) - containing the merged small variants for the depth plot.
+1. A VCF file (`.vcf`) - Provides allele counts (AD) and depth (DP) for the BAF plot.
+2. A GVCF file (`.gvcf`) - containing the depth across all sites for the depth plot.
 3. R packages (`.tar.gz`) - compressed tarball of R packages needed to generate plot.
 <br>
+
+### Optional input Parameters:
+
+#### Parameters for BAF plot:
+- `min_baf` : The minimum BAF for the baf plot. Default is 0.04
+- `max_baf` : The maximum BAF for the baf plot. Default is 0.96
+- `min_depth` : The minimum depth for the BAF plot. Default is 5
+- `symmetry` : Input to plot symmetrical points on the BAF plot. Default is true.
+
+#### Parameters for Depth plot:
+- `bin_size` : The bin size to use for plotting depth.
+- `max_depth` : The maximum depth for the plots used to set the y-axis. Points above this cut are drawn in magenta. Default is 0.9.
+
+
+#### Common Parameters for both plots:
+- `bed_filter` : The BED file used to filter the input VCFs.
+- `genome` : Genome build for plotting. Default is hg19, alternative value is hg38.
+- `min_qual` : The minimum QUAL of variants for plotting. Default is 0
+- `chr_names` : Chromosome names used for axis labels and to filter VCF contigs.
+- `output_tsv` : Whether to output a TSV file of the BAF dataframe for testing purposes. Default is False.
 
 **R Packages and Versions:**
 
@@ -38,6 +58,15 @@ sudo apt-get install -y libssl-dev libxml2-dev gcc pkg-config
 ## What does this app output?
 This app outputs:
 - `{prefix}.png` : Image of the generated plot in PNG format.
+
+### If output_tsv is set to True:
+- `prefix`.vcf.baf.tsv : tsv that contains the fields `Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF`
+- `prefix`.filtered.baf.tsv tsv that contains the fields `Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF` with variants with Depth >= min_depth and between `min_baf` and `max_baf`.
+- `prefix`.gcf.baf.tsv : Contains the Chr, Position and Depth from the GVCF input.
+- `prefix`.binned.baf.tsv : Contains the binned version of GVCF depth data. Contains `Chr, Position, mean_depth`
+
+
+
 
 
 ## How to run this app from command line?

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Plots BAF and depth of variants from given VCF/GVCF pair. The output PNG contain
 - `min_baf` : The minimum BAF for the baf plot. Default is 0.04
 - `max_baf` : The maximum BAF for the baf plot. Default is 0.96
 - `min_depth` : The minimum depth for the BAF plot. Default is 5
-- `symmetry` : Input to plot symmetrical points on the BAF plot (BAF and 1-BAF). Default is true.
+- `symmetry` : Whether to plot symmetrical points on the BAF plot (BAF and 1-BAF). Default is true.
 
 #### Parameters for Depth plot:
 - `bin_size` : The bin size to use for plotting depth.
-- `max_depth` : The maximum depth for the plots (percentile) used to set the y-axis. Points above this cut are drawn in magenta. Default is 0.9.
+- `max_depth` : The maximum depth for the depth plot (percentile) used to set the y-axis. Points above this cut are drawn in magenta. Default is 0.9.
 
 
 #### Common Parameters for both plots:
@@ -61,7 +61,7 @@ This app outputs:
 
 ### If output_tsv is set to True:
 - `prefix`.vcf.baf.tsv : tsv that contains the fields `Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF`
-- `prefix`.filtered.baf.tsv tsv that contains the fields `Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF` from the VCF input used for BAF plots. It contains  variants with Depth >= min_depth and between `min_baf` and `max_baf`.
+- `prefix`.filtered.baf.tsv tsv that contains the fields `Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF` from the VCF input used for BAF plots. It contains variants with Depth >= min_depth and between `min_baf` and `max_baf`.
 - `prefix`.gvcf.baf.tsv : Contains the Chr, Position and Depth from the GVCF input.
 - `prefix`.binned.baf.tsv : Contains the binned version of GVCF depth data. Contains `Chr, Position, mean_depth`
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # eggd_plot_variant_baf
 
 ## What does this app do?
-Plots BAF and depth of variants from given VCF/GVCF pair. The BAF plot is the top panel and the Depth plot is the bottom panel.
+Plots BAF and depth of variants from given VCF/GVCF pair. The output PNG contains two panels. The BAF plot is the top panel and the Depth plot is the bottom panel.
 
 
 ## What data are required for this app to run?
@@ -17,11 +17,11 @@ Plots BAF and depth of variants from given VCF/GVCF pair. The BAF plot is the to
 - `min_baf` : The minimum BAF for the baf plot. Default is 0.04
 - `max_baf` : The maximum BAF for the baf plot. Default is 0.96
 - `min_depth` : The minimum depth for the BAF plot. Default is 5
-- `symmetry` : Input to plot symmetrical points on the BAF plot. Default is true.
+- `symmetry` : Input to plot symmetrical points on the BAF plot (BAF and 1-BAF). Default is true.
 
 #### Parameters for Depth plot:
 - `bin_size` : The bin size to use for plotting depth.
-- `max_depth` : The maximum depth for the plots used to set the y-axis. Points above this cut are drawn in magenta. Default is 0.9.
+- `max_depth` : The maximum depth for the plots (percentile) used to set the y-axis. Points above this cut are drawn in magenta. Default is 0.9.
 
 
 #### Common Parameters for both plots:
@@ -61,8 +61,8 @@ This app outputs:
 
 ### If output_tsv is set to True:
 - `prefix`.vcf.baf.tsv : tsv that contains the fields `Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF`
-- `prefix`.filtered.baf.tsv tsv that contains the fields `Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF` with variants with Depth >= min_depth and between `min_baf` and `max_baf`.
-- `prefix`.gcf.baf.tsv : Contains the Chr, Position and Depth from the GVCF input.
+- `prefix`.filtered.baf.tsv tsv that contains the fields `Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF` from the VCF input used for BAF plots. It contains  variants with Depth >= min_depth and between `min_baf` and `max_baf`.
+- `prefix`.gvcf.baf.tsv : Contains the Chr, Position and Depth from the GVCF input.
 - `prefix`.binned.baf.tsv : Contains the binned version of GVCF depth data. Contains `Chr, Position, mean_depth`
 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Plots BAF and depth of variants from given VCF/GVCF pair. The output PNG contain
 - `bed_filter` : The BED file used to filter the input VCFs.
 - `genome` : Genome build for plotting. Default is hg19, alternative value is hg38.
 - `min_qual` : The minimum QUAL of variants for plotting. Default is 0
-- `chr_names` : Chromosome names used for axis labels and to filter VCF contigs.
+- `chr_names` : Chromosome names used for axis labels and to filter VCF contigs. They must be a subset of the chromosomes in the input VCFs.
 - `output_tsv` : Whether to output a TSV file of the BAF dataframe for testing purposes. Default is False.
 
 **R Packages and Versions:**

--- a/dxapp.json
+++ b/dxapp.json
@@ -93,6 +93,16 @@
         "help": "Minimum QUAL of variants for plotting. Default is 0"
       },
       {
+        "name": "bed_filter",
+        "label": "Bed used to filter the VCF and GVCF",
+        "class": "file",
+        "optional": true,
+        "help": "BED files used to filter the VCF and GVCF (eg. capture regions). If not provided, all variants will be used.",
+        "patterns": [
+          "*.bed$", "*.bed.gz$"
+        ]
+      },
+      {
         "name": "bin_size",
         "label": "Bin size",
         "class": "int",

--- a/src/script.sh
+++ b/src/script.sh
@@ -49,6 +49,18 @@ main() {
         fi
         bcftools index -t "${!var}"
     done
+echo "bed_filter_path = $bed_filter_path"
+
+    # Filter by BED if provided
+    if [ -n "$bed_filter_path" ]; then
+        echo "Filtering VCF and gVCF by BED regions from $bed_filter_path"
+        bcftools view -R "$bed_filter_path" "$vcf_path" -Oz -o tmp.vcf.gz && mv tmp.vcf.gz "$vcf_path"
+        bcftools index -f -t "$vcf_path"
+
+        echo "Applying BED filter to gVCF"
+        bcftools view -R "$bed_filter_path" "$gvcf_path" -Oz -o tmp.gvcf.gz && mv tmp.gvcf.gz "$gvcf_path"
+        bcftools index -f -t "$gvcf_path"
+    fi
 
     if [[ "$min_qual" -gt 0 ]]; then
         echo "Filtering VCF: keeping QUAL >= ${min_qual}"

--- a/src/script.sh
+++ b/src/script.sh
@@ -53,6 +53,16 @@ echo "bed_filter_path = $bed_filter_path"
 
     # Filter by BED if provided
     if [ -n "$bed_filter_path" ]; then
+        # Check for BED file compression and index:
+        # If the file is gzipped (.gz), it must be indexed for bcftools -R
+        if [[ "$bed_filter_path" == *.gz ]]; then
+            # Check if the required .tbi or .csi index exists
+            if ! [ -f "${bed_filter_path}.tbi" ] && ! [ -f "${bed_filter_path}.csi" ]; then
+                tabix -p bed "$bed_filter_path"
+            else
+                echo "BED file is gzipped and index found."
+            fi
+        fi
         echo "Filtering VCF and gVCF by BED regions from $bed_filter_path"
         bcftools view -R "$bed_filter_path" "$vcf_path" -Oz -o tmp.vcf.gz && mv tmp.vcf.gz "$vcf_path"
         bcftools index -f -t "$vcf_path"


### PR DESCRIPTION
- Closes #30 #21, improving the README.md and explaining which input corresponds to which plot.
- Implements a new optional parameter `bed_filter` to filter by BED file, thus enabling filtering for CEN and TWE and the production of more informative plots.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_plot_variant_baf/31)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional BED-based region filtering for VCF/gVCF inputs (accepts gzipped BED, auto-indexing if needed); preserved default behaviour when not provided. Input parameter added to app specification.

- **Documentation**
  - Expanded README: two-panel PNG layout (BAF top, Depth bottom), clarified VCF/GVCF input expectations, detailed optional parameters and defaults, listed R packages/versions and build steps, described TSV outputs and filtering criteria, and added command-line usage example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->