### PR TITLE
V2.3.0 ram optimisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This app outputs:
 
 
 ## How to run this app from command line?
-With essential imput parameters:
+With essential input parameters:
 ```
 dx run eggd_plot_variant_baf \
 -ivcf=file-xxxx \
@@ -77,7 +77,7 @@ dx run eggd_plot_variant_baf \
 -ipackages=file-xxxx  \
 --destination="output/eggd_plot_variant_baf"
 ```
-With all possible imput parameters:
+With all possible input parameters:
 ```
 dx run eggd_plot_variant_baf \
   -ivcf=project-xxxx:file-xxxx \

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Plots BAF and depth of variants from given VCF/GVCF pair. The output PNG contain
 - `symmetry` : Whether to plot symmetrical points on the BAF plot (BAF and 1-BAF). Default is true.
 
 #### Parameters for Depth plot:
-- `bin_size : The bin size to use for plotting depth. If left blank, the app will dynamically calculate an appropriate bin size based on the input size. It defaults to a bin size of 1 for small targeted datasets (fewer than 2,000 data points).
+- `bin_size` : The bin size to use for plotting depth. If left blank, the app will dynamically calculate an appropriate bin size based on the input size. It defaults to a bin size of 1 for small targeted datasets (fewer than 2,000 data points).
 - `max_depth` : The maximum depth for the depth plot (percentile) used to set the y-axis. Points above this cut are drawn in magenta. Default is 0.9.
 
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This app outputs:
 - `{prefix}.png` : Image of the generated plot in PNG format.
 
 ### If output_tsv is set to True:
-- `{SAMPLE_NAME}.vcf.baf.tsv` : TSV containing the raw, unfiltered data from the VCF input. Includes fields Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF.
+- `{SAMPLE_NAME}.vcf.baf.tsv` : TSV containing the filtered and calculated data from the VCF input before plotting. Includes fields Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF.
 - `{SAMPLE_NAME}.gvcf.baf.tsv` : TSV containing the raw data from the GVCF input. Includes fields Chr, Position, Depth.
 
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ This app outputs:
 - `{prefix}.png` : Image of the generated plot in PNG format.
 
 ### If output_tsv is set to True:
-{SAMPLE_NAME}.vcf.baf.tsv : TSV containing the raw, unfiltered data from the VCF input. Includes fields Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF.
-{SAMPLE_NAME}.gvcf.baf.tsv : TSV containing the raw data from the GVCF input. Includes fields Chr, Position, Depth.
+- `{SAMPLE_NAME}.vcf.baf.tsv` : TSV containing the raw, unfiltered data from the VCF input. Includes fields Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF.
+- `{SAMPLE_NAME}.gvcf.baf.tsv` : TSV containing the raw data from the GVCF input. Includes fields Chr, Position, Depth.
 
 
 ## How to run this app from command line?

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ dx run eggd_plot_variant_baf \
 -imin_depth=20 \
 -imin_baf=0 \
 -imax_baf=1
--ipackages=file-xxxx  \
+-ipackages_path=file-xxxx  \
 --destination="output/eggd_plot_variant_baf"
 ```
 With all possible input parameters:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ dx run eggd_plot_variant_baf \
 -imin_depth=20 \
 -imin_baf=0 \
 -imax_baf=1
--ipackages_path=file-xxxx  \
+-ipackages=file-xxxx  \
 --destination="output/eggd_plot_variant_baf"
 ```
 With all possible input parameters:
@@ -82,7 +82,7 @@ With all possible input parameters:
 dx run eggd_plot_variant_baf \
 -ivcf=project-xxxx:file-xxxx \
 -igvcf=project-xxxx:file-xxxx \
--ipackages_path=project-xxxx:file-xxxx \
+-ipackages=project-xxxx:file-xxxx \
 -ibed_filter=project-xxxx:file-xxxx \
 -imin_baf=0.05 \
 -imax_baf=0.95 \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Plots BAF and depth of variants from given VCF/GVCF pair. The output PNG contain
 - `max_baf` : The maximum BAF for the baf plot. Default is 0.96
 - `min_depth` : The minimum depth for the BAF plot. Default is 5
 - `symmetry` : Whether to plot symmetrical points on the BAF plot (BAF and 1-BAF). Default is true.
-- `max_pop_af` : The maximum Population Allele Frequency to keep (e.g., 0.05). If NULL, no AF filtering is applied.Default is NULL.
 
 #### Parameters for Depth plot:
 - `bin_size : The bin size to use for plotting depth. If left blank, the app will dynamically calculate an appropriate bin size based on the input size. It defaults to a bin size of 1 for small targeted datasets (fewer than 2,000 data points).

--- a/README.md
+++ b/README.md
@@ -76,3 +76,22 @@ dx run eggd_plot_variant_baf \
 -ipackages=file-xxxx  \
 --destination="output/eggd_plot_variant_baf"
 ```
+With all possible imput parametres
+```
+dx run eggd_plot_variant_baf \
+  -ivcf=project-xxxx:file-xxxx \
+  -igvcf=project-xxxx:file-xxxx \
+  -ipackages_path=project-xxxx:file-xxxx \
+  -ibed_filter=project-xxxx:file-xxxx \
+  -imin_baf=0.05 \
+  -imax_baf=0.95 \
+  -imin_depth=20 \
+  -isymmetry=true \
+  -ibin_size=1000 \
+  -imax_depth=0.98 \
+  -igenome="hg38" \
+  -imin_qual=30 \
+  -ichr_names="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y" \
+  -ioutput_tsv=true \
+  --destination="project-xxxx:/output/eggd_plot_variant_baf"
+```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Plots BAF and depth of variants from given VCF/GVCF pair. The output PNG contain
 - `max_baf` : The maximum BAF for the baf plot. Default is 0.96
 - `min_depth` : The minimum depth for the BAF plot. Default is 5
 - `symmetry` : Whether to plot symmetrical points on the BAF plot (BAF and 1-BAF). Default is true.
+- `max_pop_af` : The maximum Population Allele Frequency to keep (e.g., 0.05). If NULL, no AF filtering is applied.Default is NULL.
 
 #### Parameters for Depth plot:
 - `bin_size : The bin size to use for plotting depth. If left blank, the app will dynamically calculate an appropriate bin size based on the input size. It defaults to a bin size of 1 for small targeted datasets (fewer than 2,000 data points).
@@ -80,19 +81,20 @@ dx run eggd_plot_variant_baf \
 With all possible input parameters:
 ```
 dx run eggd_plot_variant_baf \
-  -ivcf=project-xxxx:file-xxxx \
-  -igvcf=project-xxxx:file-xxxx \
-  -ipackages_path=project-xxxx:file-xxxx \
-  -ibed_filter=project-xxxx:file-xxxx \
-  -imin_baf=0.05 \
-  -imax_baf=0.95 \
-  -imin_depth=20 \
-  -isymmetry=true \
-  -ibin_size=1000 \
-  -imax_depth=0.98 \
-  -igenome="hg38" \
-  -imin_qual=30 \
-  -ichr_names="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y" \
-  -ioutput_tsv=true \
-  --destination="project-xxxx:/output/eggd_plot_variant_baf"
+-ivcf=project-xxxx:file-xxxx \
+-igvcf=project-xxxx:file-xxxx \
+-ipackages_path=project-xxxx:file-xxxx \
+-ibed_filter=project-xxxx:file-xxxx \
+-imin_baf=0.05 \
+-imax_baf=0.95 \
+-imin_depth=20 \
+-isymmetry=true \
+-imax_pop_af=0.05 \
+-ibin_size=1000 \
+-imax_depth=0.98 \
+-igenome="hg38" \
+-imin_qual=30 \
+-ichr_names="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y" \
+-ioutput_tsv=true \
+--destination="project-xxxx:/output/eggd_plot_variant_baf"
 ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This app outputs:
 
 
 ## How to run this app from command line?
+With essential imput parameters:
 ```
 dx run eggd_plot_variant_baf \
 -ivcf=file-xxxx \
@@ -76,7 +77,7 @@ dx run eggd_plot_variant_baf \
 -ipackages=file-xxxx  \
 --destination="output/eggd_plot_variant_baf"
 ```
-With all possible imput parametres
+With all possible imput parameters:
 ```
 dx run eggd_plot_variant_baf \
   -ivcf=project-xxxx:file-xxxx \

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Plots BAF and depth of variants from given VCF/GVCF pair. The output PNG contain
 - `symmetry` : Whether to plot symmetrical points on the BAF plot (BAF and 1-BAF). Default is true.
 
 #### Parameters for Depth plot:
-- `bin_size` : The bin size to use for plotting depth.
+- `bin_size : The bin size to use for plotting depth. If left blank, the app will dynamically calculate an appropriate bin size based on the input size. It defaults to a bin size of 1 for small targeted datasets (fewer than 2,000 data points).
 - `max_depth` : The maximum depth for the depth plot (percentile) used to set the y-axis. Points above this cut are drawn in magenta. Default is 0.9.
 
 
@@ -60,13 +60,8 @@ This app outputs:
 - `{prefix}.png` : Image of the generated plot in PNG format.
 
 ### If output_tsv is set to True:
-- `prefix`.vcf.baf.tsv : tsv that contains the fields `Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF`
-- `prefix`.filtered.baf.tsv tsv that contains the fields `Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF` from the VCF input used for BAF plots. It contains variants with Depth >= min_depth and between `min_baf` and `max_baf`.
-- `prefix`.gvcf.baf.tsv : Contains the Chr, Position and Depth from the GVCF input.
-- `prefix`.binned.baf.tsv : Contains the binned version of GVCF depth data. Contains `Chr, Position, mean_depth`
-
-
-
+{SAMPLE_NAME}.vcf.baf.tsv : TSV containing the raw, unfiltered data from the VCF input. Includes fields Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF.
+{SAMPLE_NAME}.gvcf.baf.tsv : TSV containing the raw data from the GVCF input. Includes fields Chr, Position, Depth.
 
 
 ## How to run this app from command line?

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ dx run eggd_plot_variant_baf \
 -imax_baf=0.95 \
 -imin_depth=20 \
 -isymmetry=true \
--imax_pop_af=0.05 \
 -ibin_size=1000 \
 -imax_depth=0.98 \
 -igenome="hg38" \

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This app outputs:
 - `{prefix}.png` : Image of the generated plot in PNG format.
 
 ### If output_tsv is set to True:
-- `{SAMPLE_NAME}.vcf.baf.tsv` : TSV containing the filtered and calculated data from the VCF input before plotting. Includes fields Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF.
+- `{SAMPLE_NAME}.vcf.baf.tsv` : TSV containing the filtered and calculated data from the VCF input before plotting. Includes fields Chr, Position, Ref_AD, Alt_AD, RAF, BAF.
 - `{SAMPLE_NAME}.gvcf.baf.tsv` : TSV containing the raw data from the GVCF input. Includes fields Chr, Position, Depth.
 
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -23,7 +23,12 @@
             "version": "2.2.0",
             "date": "2025-09-29",
             "description": "Updated the app to take an optional BED to filter inputs."
-        }
+        },
+        {
+            "version": "2.3.0",
+            "date": "2026-07-23",
+            "description": "Updated the app to reduce the RAM usage by downsampling and improved memory management."
+        }    
     ],
     "inputSpec":
     [

--- a/dxapp.json
+++ b/dxapp.json
@@ -48,7 +48,7 @@
         "help": "GVCF"
       },
       {
-        "name": "packages_path",
+        "name": "packages",
         "label": "R Packages",
         "class": "file",
         "optional": false,

--- a/dxapp.json
+++ b/dxapp.json
@@ -48,7 +48,7 @@
         "help": "GVCF"
       },
       {
-        "name": "packages",
+        "name": "packages_path",
         "label": "R Packages",
         "class": "file",
         "optional": false,

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -141,7 +141,7 @@ read_to_df <- function(file) {
 # @parameter sym - logical: whether to add symmetrical BAF values
 # Returns df 
 calculate_baf <- function(df, sym) {
-  df[c("Ref_AD", "Alt_AD")] <- str_split_fixed(df$Allele_Depth, ",", 2)
+  df[c("Ref_AD", "Alt_AD")] <- str_split_fixed(df$Allele_Depth, ",", 3)[, 1:2]
   df$RAF <- as.numeric(df$Ref_AD)
   df$BAF <- as.numeric(df$Alt_AD)
   # Avoid division by zero
@@ -319,7 +319,7 @@ if (is.null(BIN_SIZE)) {
 # aggregate gvcf df into binned df for depth plot
 df_binned <- bin_df(df_gvcf, BIN_SIZE)
 snp.data.depth_full <- get_snp_data_Depth(df_binned)
-df_full <- data.frame(x = snp.data.depth_full)
+df_full <- data.frame(x=snp.data.depth_full)
 median_depths <- tapply(df_full$x.mean_depth, df_full$x.seqnames, median, na.rm = TRUE)
 
 # DOWNSAMPLE BINNED DATA for readability and memory reduction

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -317,9 +317,8 @@ if (is.null(BIN_SIZE)) {
 
 # aggregate gvcf df into binned df for depth plot
 df_binned <- bin_df(df_gvcf, BIN_SIZE)
-snp.data.depth_full <- get_snp_data_Depth(df_binned)
-df_full <- data.frame(x=snp.data.depth_full)
-median_depths <- tapply(df_full$x.mean_depth, df_full$x.seqnames, median, na.rm = TRUE)
+snp_data <- get_snp_data_Depth(df_binned)
+median_depths <- tapply(snp_data$mean_depth, snp_data$seqnames, median, na.rm = TRUE)
 
 # DOWNSAMPLE BINNED DATA for readability and memory reduction
 # 50,000 points is more than enough to clearly see depth distribution without blacking out the plot

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -319,8 +319,9 @@ if (is.null(BIN_SIZE)) {
 
 # aggregate gvcf df into binned df for depth plot
 df_binned <- bin_df(df_gvcf, BIN_SIZE)
-snp_data <- get_snp_data_Depth(df_binned)
-median_depths <- tapply(snp_data$mean_depth, snp_data$seqnames, median, na.rm = TRUE)
+snp.data.depth <- get_snp_data_Depth(df_binned)
+df <- data.frame(x = snp.data.depth)
+median_depths <- tapply(df$x.mean_depth, df$x.seqnames, median, na.rm = TRUE)
 
 # DOWNSAMPLE BINNED DATA for readability and memory reduction
 # 50,000 points is more than enough to clearly see depth distribution without blacking out the plot

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -275,12 +275,6 @@ df_vcf <- read_to_df(VCF_FILE)
 # read tsv file into df for DEPTH plot
 df_gvcf <- read_to_df(GVCF_FILE)
 
-if (args$output_tsv) {
-  print("User requested TSVs. Writing raw data before plotting to disk...")
-  write.table(df_vcf, file=paste0(SAMPLE_NAME, ".vcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
-  write.table(df_gvcf, file=paste0(SAMPLE_NAME, ".gvcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
-}
-
 # Filter out low depth rows for BAF plotting
 df_filtered <- df_vcf[df_vcf$Depth >= MIN_DEPTH, ]
 if (nrow(df_filtered) == 0) {
@@ -302,6 +296,12 @@ if (nrow(df_filtered) > MAX_PLOT_POINTS) {
 # calculate BAF values and add symmetrical values if required
 if (! (nrow(df_filtered) == 0)) {
   df_filtered <- calculate_baf(df_filtered, SYMMETRY)
+}
+
+if (args$output_tsv) {
+  print("User requested TSVs. Writing calculated data before plotting to disk...")
+  write.table(df_filtered, file=paste0(SAMPLE_NAME, ".vcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
+  write.table(df_gvcf, file=paste0(SAMPLE_NAME, ".gvcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
 }
 
 # get quantiles for plotting limits

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -319,7 +319,7 @@ if (is.null(BIN_SIZE)) {
 # aggregate gvcf df into binned df for depth plot
 df_binned <- bin_df(df_gvcf, BIN_SIZE)
 snp.data.depth_full <- get_snp_data_Depth(df_binned)
-df_full <- as.data.frame(snp.data.depth_full)
+df_full <- data.frame(x = snp.data.depth_full)
 median_depths <- tapply(df_full$x.mean_depth, df_full$x.seqnames, median, na.rm = TRUE)
 
 # DOWNSAMPLE BINNED DATA for readability and memory reduction

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -114,7 +114,7 @@ read_to_df <- function(file) {
     return(empty_df)
   }
   else {
-    df <- data.table::fread(file, header = FALSE)
+    df <- data.table::fread(file, header = FALSE, sep = "\t", na.strings = c("NA", ".", ""))
     if (ncol(df) == 4) {
     colnames(df) <- c("Chr", "Position", "Depth", "Allele_Depth")
     # Remove rows with NA in Depth or Allele_Depth

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -141,7 +141,7 @@ read_to_df <- function(file,max_pop_af = NULL) {
 # @parameter sym - logical: whether to add symmetrical BAF values
 # Returns df 
 calculate_baf <- function(df, sym) {
-  df[c("Ref_AD", "Alt_AD")] <- str_split_fixed(df$Allele_Depth, ",", 3)[, 1:2]
+  df[c("Ref_AD", "Alt_AD")] <- str_split_fixed(df$Allele_Depth, ",", 2)
   df$RAF <- as.numeric(df$Ref_AD)
   df$BAF <- as.numeric(df$Alt_AD)
   # Avoid division by zero

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -251,10 +251,11 @@ get_plot <- function(snp.data.baf, snp.data.depth, file_name, max_depth, chr_nam
   df <- data.frame(x = snp.data.depth)
   for (chr in unique(df$x.seqnames)) {
     # Subset the vector using the chromosome name
+    #median_depths <- tapply(df$x.mean_depth, df$x.seqnames, median, na.rm = TRUE) 
     median_depth <- median_depths[chr]
     if (!is.na(median_depth)) {
       prop <- median_depth / max_depth # scale to the bottom plot
-      kpAbline(baf_depth_plot, h=prop, chr=chr, col = "darkred", lwd = 3, r0 = 0, r1 = 0.45, ymin = 0, ymax = max_depth)
+      kpAbline(baf_depth_plot, h=prop, chr=chr, col = "darkred", lwd = 3, r0 = 0, r1 = 0.45)
     }
   }
   kpAddMainTitle(baf_depth_plot, main = title)

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -50,8 +50,6 @@ parser$add_argument("--symmetry", type="logical", default=TRUE,
     help="Whether to plot BAF symmetrically [default %(default)s]")
 parser$add_argument("--output_tsv", type="logical", default=FALSE,
     help="Whether to write TSV outputs [default %(default)s]")
-parser$add_argument("--max_pop_af", type="double", default=NULL,
-    help="Maximum Population Allele Frequency to keep (e.g., 0.05). If NULL, no AF filtering is applied.")
 
 # get command line options, if help option encountered print help and exit,
 # otherwise if options not found on command line then set defaults,
@@ -117,20 +115,10 @@ read_to_df <- function(file,max_pop_af = NULL) {
   }
   else {
     df <- data.table::fread(file, header = FALSE)
-    if (ncol(df) == 5) {
-      df <- df[, 1:5]
-      colnames(df) <- c("Chr", "Position", "Depth", "Allele_Depth", "Pop_AF")
+    if (ncol(df) == 4) {
+    colnames(df) <- c("Chr", "Position", "Depth", "Allele_Depth")
     # Remove rows with NA in Depth or Allele_Depth
     df <- df[!is.na(df$Allele_Depth) & !is.na(df$Depth), ]
-
-    # Filter out common variants (e.g., Population AF > 5%)
-    # Coerce to numeric in case missing values were parsed as "."
-    if (!is.null(max_pop_af)) {
-        suppressWarnings({
-          df$Pop_AF <- as.numeric(as.character(df$Pop_AF))
-        })
-        df <- df[is.na(df$Pop_AF) | df$Pop_AF <= max_pop_af, ]
-      }
     } else if (ncol(df) == 3) {
       colnames(df) <- c("Chr", "Position", "Depth")
       # Remove rows with NA in Depth

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -16,6 +16,10 @@ library(karyoploteR, quietly = TRUE)
 library(dplyr, quietly = TRUE)
 library(polars, quietly = TRUE)
 library(argparse, quietly = TRUE)
+library(data.table, quietly = TRUE)
+#library(ggplot2, quietly = TRUE)
+#library(plotly, quietly = TRUE)
+#library(htmlwidgets, quietly = TRUE)
 
 # Get configurable inputs via command line
 ####################################################
@@ -45,12 +49,12 @@ parser$add_argument("--genome", type="character", default="hg19",
     help="Genome build for plotKaryotype function [default %(default)s]")
 parser$add_argument("--symmetry", type="logical", default=TRUE,
     help="Whether to plot BAF symmetrically [default %(default)s]")
-                                        
+
 # get command line options, if help option encountered print help and exit,
 # otherwise if options not found on command line then set defaults,
 args <- parser$parse_args()
 
-# Validate percentile parameter  
+# Validate percentile parameter
 if (args$max_depth < 0 || args$max_depth > 1) {
   stop("max_depth must be a percentile value between 0 and 1")
 }
@@ -109,25 +113,26 @@ read_to_df <- function(file) {
     return(empty_df)
   }
   else {
-    df <- read.table(file = file, header = FALSE)
+    df <- data.table::fread(file, header = FALSE)
     if (ncol(df) == 4) {
-    colnames(df) <- c("Chr", "Position", "Depth", "Allele_Depth")
+      df <- df[, 1:4]
+      colnames(df) <- c("Chr", "Position", "Depth", "Allele_Depth")
     # Remove rows with NA in Depth or Allele_Depth
     df <- df[!is.na(df$Allele_Depth) & !is.na(df$Depth), ]
     } else if (ncol(df) == 3) {
       colnames(df) <- c("Chr", "Position", "Depth")
-      # Remove rows with NA in Depth 
+      # Remove rows with NA in Depth
       df <- df[!is.na(df$Depth), ]
     }
     else {
       stop("Invalid TSV format: Expected 3 or 4 columns (CHROM, POS, DP[, AD])")
     }
     # Check Position & Depth are numeric
-    if (!all(sapply(df[c("Position", "Depth")], is.numeric))) {
-      stop("Invalid TSV: Position and Depth must be numeric")
+    if (!is.numeric(df$Position) || !is.numeric(df$Depth)) {
+        stop("Invalid TSV: Position and Depth must be numeric")
     }
     # Return Dataframe
-    return(df)
+    return(as.data.frame(df))
 }
 }
 
@@ -148,7 +153,7 @@ calculate_baf <- function(df, sym) {
       symmetric_df$BAF <- 1 - df$BAF
       df <- rbind(df, symmetric_df)
     }
-  return(df)
+  return(as.data.frame(df))
 } 
 
 # Function to return dfs with binned depth
@@ -157,15 +162,16 @@ calculate_baf <- function(df, sym) {
 # returns df_binned
 
 bin_df <- function(df, bin_size) {
-  polars_df <- as_polars_df(df[order(df$Chr, df$Position), ])
-  rolling_df <- polars_df$rolling(
-    index_column = "Position",
-    group_by = "Chr",
-    period = paste(as.character(bin_size), "i", sep = "")
-  )$agg(mean_depth = pl$mean("Depth"))$gather_every(bin_size)
-  df_binned <- rolling_df$to_data_frame()
-
-  return(df_binned)
+  # Convert to data.table by reference (no memory copy)
+  setDT(df)
+  # Sort in place
+  setorder(df, Chr, Position)
+  # Create bin groups and calculate mean depth simultaneously
+  df[, bin := floor(Position / bin_size) * bin_size]
+  df_binned <- df[, .(Position = bin[1], mean_depth = mean(Depth, na.rm = TRUE)), by = .(Chr, bin)]
+  # Remove the temporary bin column
+  df_binned[, bin := NULL]
+  return(as.data.frame(df_binned))
 }
 
 
@@ -200,7 +206,7 @@ get_snp_data_Depth <- function(df) {
 # @parameters min_baf and max_baf - integers : include only variants in range min_baf < BAF < max_baf
 # returns plot
 
-get_plot <- function(snp.data.baf, snp.data.depth, file_name, max_depth, chr_names, min_baf, max_baf, genome_build) {
+get_plot <- function(snp.data.baf, snp.data.depth, file_name, max_depth, chr_names, min_baf, max_baf, genome_build, median_depths) {
   file_name_png <- paste0(SAMPLE_NAME, ".baf.png")
   png(file_name_png, width = 15, height = 5, units = "in", res = 600)
   plot_parameters <- getDefaultPlotParams(plot.type = 4)
@@ -208,40 +214,47 @@ get_plot <- function(snp.data.baf, snp.data.depth, file_name, max_depth, chr_nam
   baf_depth_plot <- plotKaryotype(genome = genome_build, plot.type = 4, ideogram.plotter = NULL, plot.params = plot_parameters, labels.plotter = NULL)
   kpAddChromosomeNames(baf_depth_plot, chr.names = chr_names)
   kpAddCytobandsAsLine(baf_depth_plot) # Add centromeres
+
+  # Alpha transparency added here to prevent blobs
+  col_baf <- adjustcolor("darkorange2", alpha.f = 0.3)
+  col_depth_norm <- adjustcolor("darkblue", alpha.f = 0.3)
+  col_depth_high <- adjustcolor("magenta", alpha.f = 0.3)
+
   # top graph
   baf_threshold <- which(snp.data.baf$BAF > min_baf & snp.data.baf$BAF <= max_baf)
-  modified_high_depth <- snp.data.depth$mean_depth > max_depth # get values above max_depth
-  snp.data.depth$mean_depth <- pmin(snp.data.depth$mean_depth, max_depth) # assign the max to max_depth
-  modified_depth <- ifelse(
-    modified_high_depth, 'magenta', 'darkblue'
-  ) # Assign colors based on the mean_depth
+  modified_high_depth <- snp.data.depth$mean_depth > max_depth 
+  snp.data.depth$mean_depth <- pmin(snp.data.depth$mean_depth, max_depth) 
+
+  modified_depth <- ifelse(modified_high_depth, col_depth_high, col_depth_norm) 
+
   kpAxis(baf_depth_plot, r0 = 0.55, r1 = 1, tick.pos = c(0, 0.25, 0.5, 0.75, 1))
   kpAbline(baf_depth_plot, h=c(0.25, 0.5, 0.75), lty = 0.5, r0 =0.55, r1=1)
-  # only add points if snp.data.baf is not empty
+
   if (length(snp.data.baf) > 0) {
+    # Reduced point size (cex)
     kpPoints(baf_depth_plot,
       data = snp.data.baf[baf_threshold], y = snp.data.baf[baf_threshold]$BAF,
-      cex = 0.5, r0 = 0.55, r1 = 1, col = "darkorange2"
+      cex = 0.2, r0 = 0.55, r1 = 1, col = col_baf
     )
-    title = paste0("BAF vs Depth for ", SAMPLE_NAME)
-  }
-  else {
-    title = paste0("Provided VCFs contain insufficient data for plotting - ", SAMPLE_NAME)
+    title <- paste0("BAF vs Depth for ", SAMPLE_NAME)
+  } else {
+    title <- paste0("Provided VCFs contain insufficient data for plotting - ", SAMPLE_NAME)
   }
   # bottom graph
   kpAxis(baf_depth_plot, r0 = 0, r1 = 0.45, ymax = max_depth, ymin = 0)
   kpPoints(baf_depth_plot,
     data = snp.data.depth, y = snp.data.depth$mean_depth,
-    cex = 0.5, r0 = 0, r1 = 0.45, ymax = max_depth, ymin = 0, col = modified_depth
+    cex = 0.2, r0 = 0, r1 = 0.45, ymax = max_depth, ymin = 0, col = modified_depth
   )
+
   # add horizontal line at median depth for each chromosome
   df <- data.frame(x = snp.data.depth)
-  median_depths <- tapply(df$x.mean_depth, df$x.seqnames, median, na.rm = TRUE)
   for (chr in unique(df$x.seqnames)) {
+    # Subset the vector using the chromosome name
     median_depth <- median_depths[chr]
-    prop <- median_depth / max_depth # scale to the bottom plot
     if (!is.na(median_depth)) {
-      kpAbline(baf_depth_plot, h=prop, chr=chr, col = "darkred", lwd = 3, r0 = 0, r1 = 0.45)
+      prop <- median_depth / max_depth # scale to the bottom plot
+      kpAbline(baf_depth_plot, h=prop, chr=chr, col = "darkred", lwd = 3, r0 = 0, r1 = 0.45, ymin = 0, ymax = max_depth)
     }
   }
   kpAddMainTitle(baf_depth_plot, main = title)
@@ -255,15 +268,27 @@ get_plot <- function(snp.data.baf, snp.data.depth, file_name, max_depth, chr_nam
 
 # read tsv file into df for BAF plot
 df_vcf <- read_to_df(VCF_FILE)
+write.table(df_vcf, file=paste0(SAMPLE_NAME, ".vcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
 
 # read tsv file into df for DEPTH plot
 df_gvcf <- read_to_df(GVCF_FILE)
+write.table(df_gvcf, file=paste0(SAMPLE_NAME, ".gvcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
+
+# DOWNSAMPLE BAF for readability and memory reduction
+# 50,000 points is more than enough to clearly see zygosity without blacking out the plot
+
+set.seed(42)
+
+MAX_PLOT_POINTS <- 50000
+if (nrow(df_vcf) > MAX_PLOT_POINTS) {
+  print(paste("Downsampling BAF data from", nrow(df_vcf), "to", MAX_PLOT_POINTS, "points for plot readability..."))
+  df_vcf <- df_vcf[sample(nrow(df_vcf), MAX_PLOT_POINTS), ]
+}
 
 # calculate BAF values and add symmetrical values if required
 if (! (nrow(df_vcf) == 0)) {
   df_vcf <- calculate_baf(df_vcf, SYMMETRY)
 }
-
 
 # get quantiles for plotting limits
 MAX_DEPTH <- round(quantile(df_gvcf$Depth, probs = MAX_DEPTH_PCT, names = FALSE), digits = 0)
@@ -283,14 +308,26 @@ BIN_SIZE <- ifelse(
 
 # aggregate gvcf df into binned df for depth plot
 df_binned <- bin_df(df_gvcf, BIN_SIZE)
+snp.data.depth_full <- get_snp_data_Depth(df_binned)
+df_full <- data.frame(x = snp.data.depth_full)
+median_depths <- tapply(df_full$x.mean_depth, df_full$x.seqnames, median, na.rm = TRUE)
 
-# make tsvs for testing if needed
-write.table(df_vcf, file=paste0(SAMPLE_NAME, ".vcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
-write.table(df_filtered, file=paste0(SAMPLE_NAME, ".filtered.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
-write.table(df_gvcf, file=paste0(SAMPLE_NAME, ".gvcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
 write.table(df_binned, file=paste0(SAMPLE_NAME, ".binned.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
 
-# convert dfs for baf plotting into snp.data for karyoploter
+# DOWNSAMPLE BINNED DATA for readability and memory reduction
+# 50,000 points is more than enough to clearly see depth distribution without blacking out the plot
+MAX_BINNED_POINTS <- 50000
+if (nrow(df_binned) > MAX_BINNED_POINTS) {
+  print(paste("Downsampling binned depth data from", nrow(df_binned), "to", MAX_BINNED_POINTS, "points for plot readability..."))
+  # Use systematic sampling to maintain genomic distribution (taking every Nth row)
+  step_size <- ceiling(nrow(df_binned) / MAX_BINNED_POINTS)
+  df_binned <- df_binned[seq(1, nrow(df_binned), by = step_size), ]
+}
+
+# MEMORY CLEAR: Removed massive intermediate write.tables here.
+rm(df_vcf, df_gvcf)
+gc()
+
 print("Converting filtered dataframe to snp.data.baf format for karyoploter...")
 snp.data.baf <- get_snp_data_BAF(df_filtered)
 
@@ -300,5 +337,4 @@ snp.data.depth <- get_snp_data_Depth(df_binned)
 
 # generate plots and save them
 print("Generating BAF vs Depth plot...")
-get_plot(snp.data.baf, snp.data.depth, SAMPLE_NAME, MAX_DEPTH, CHR_NAMES, MIN_BAF, MAX_BAF, GENOME)
-
+get_plot(snp.data.baf, snp.data.depth, SAMPLE_NAME, MAX_DEPTH, CHR_NAMES, MIN_BAF, MAX_BAF, GENOME, median_depths)

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -14,7 +14,6 @@
 library(stringr, quietly = TRUE)
 library(karyoploteR, quietly = TRUE)
 library(dplyr, quietly = TRUE)
-library(polars, quietly = TRUE)
 library(argparse, quietly = TRUE)
 library(data.table, quietly = TRUE)
 
@@ -146,14 +145,17 @@ calculate_baf <- function(df, sym) {
   df$RAF <- ifelse(df$Depth > 0, as.numeric(df$Ref_AD) / df$Depth, NA)
   df$BAF <- ifelse((as.numeric(df$Ref_AD) + as.numeric(df$Alt_AD)) > 0, 
                    as.numeric(df$Alt_AD) / (as.numeric(df$Ref_AD) + as.numeric(df$Alt_AD)), NA) #calculate BAF strictly relative to the read counts of the two main alleles
-      # Add symmetrical values if required
+  # Delete large intermediate columns to free memory
+  df$Allele_Depth <- NULL
+
+  # Add symmetrical values if required
   if (isTRUE(sym)) {
       symmetric_df <- df
       symmetric_df$BAF <- 1 - df$BAF
       df <- rbind(df, symmetric_df)
     }
   df <- df[!is.na(df$BAF), ]
-  
+  gc()
   return(as.data.frame(df))
 } 
 

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -17,7 +17,6 @@ library(dplyr, quietly = TRUE)
 library(polars, quietly = TRUE)
 library(argparse, quietly = TRUE)
 library(data.table, quietly = TRUE)
-#library(ggplot2, quietly = TRUE)
 #library(plotly, quietly = TRUE)
 #library(htmlwidgets, quietly = TRUE)
 
@@ -49,6 +48,10 @@ parser$add_argument("--genome", type="character", default="hg19",
     help="Genome build for plotKaryotype function [default %(default)s]")
 parser$add_argument("--symmetry", type="logical", default=TRUE,
     help="Whether to plot BAF symmetrically [default %(default)s]")
+parser$add_argument("--output_tsv", type="logical", default=FALSE,
+    help="Whether to write TSV outputs [default %(default)s]")
+parser$add_argument("--max_pop_af", type="double", default=NULL,
+    help="Maximum Population Allele Frequency to keep (e.g., 0.05). If NULL, no AF filtering is applied.")
 
 # get command line options, if help option encountered print help and exit,
 # otherwise if options not found on command line then set defaults,
@@ -101,7 +104,7 @@ SYMMETRY <- isTRUE(args$symmetry)
 # Function to read files into dfs
 # @parameter file
 # returns df
-read_to_df <- function(file) {
+read_to_df <- function(file,max_pop_af = NULL) {
   if (!file.exists(file)) {
     stop("File not found: ", file)
   }
@@ -114,11 +117,20 @@ read_to_df <- function(file) {
   }
   else {
     df <- data.table::fread(file, header = FALSE)
-    if (ncol(df) == 4) {
-      df <- df[, 1:4]
-      colnames(df) <- c("Chr", "Position", "Depth", "Allele_Depth")
+    if (ncol(df) == 5) {
+      df <- df[, 1:5]
+      colnames(df) <- c("Chr", "Position", "Depth", "Allele_Depth", "Pop_AF")
     # Remove rows with NA in Depth or Allele_Depth
     df <- df[!is.na(df$Allele_Depth) & !is.na(df$Depth), ]
+
+    # Filter out common variants (e.g., Population AF > 5%)
+    # Coerce to numeric in case missing values were parsed as "."
+    if (!is.null(max_pop_af)) {
+        suppressWarnings({
+          df$Pop_AF <- as.numeric(as.character(df$Pop_AF))
+        })
+        df <- df[is.na(df$Pop_AF) | df$Pop_AF <= max_pop_af, ]
+      }
     } else if (ncol(df) == 3) {
       colnames(df) <- c("Chr", "Position", "Depth")
       # Remove rows with NA in Depth
@@ -141,18 +153,21 @@ read_to_df <- function(file) {
 # @parameter sym - logical: whether to add symmetrical BAF values
 # Returns df 
 calculate_baf <- function(df, sym) {
-  df[c("Ref_AD", "Alt_AD")] <- str_split_fixed(df$Allele_Depth, ",", 2)
+  df[c("Ref_AD", "Alt_AD")] <- str_split_fixed(df$Allele_Depth, ",", 3)[, 1:2]
   df$RAF <- as.numeric(df$Ref_AD)
   df$BAF <- as.numeric(df$Alt_AD)
   # Avoid division by zero
   df$RAF <- ifelse(df$Depth > 0, as.numeric(df$Ref_AD) / df$Depth, NA)
-  df$BAF <- ifelse(df$Depth > 0, as.numeric(df$Alt_AD) / df$Depth, NA)
+  df$BAF <- ifelse((as.numeric(df$Ref_AD) + as.numeric(df$Alt_AD)) > 0, 
+                   as.numeric(df$Alt_AD) / (as.numeric(df$Ref_AD) + as.numeric(df$Alt_AD)), NA) #calculate BAF strictly relative to the read counts of the two main alleles
       # Add symmetrical values if required
   if (isTRUE(sym)) {
       symmetric_df <- df
       symmetric_df$BAF <- 1 - df$BAF
       df <- rbind(df, symmetric_df)
     }
+  df <- df[!is.na(df$BAF), ]
+  
   return(as.data.frame(df))
 } 
 
@@ -251,7 +266,6 @@ get_plot <- function(snp.data.baf, snp.data.depth, file_name, max_depth, chr_nam
   df <- data.frame(x = snp.data.depth)
   for (chr in unique(df$x.seqnames)) {
     # Subset the vector using the chromosome name
-    #median_depths <- tapply(df$x.mean_depth, df$x.seqnames, median, na.rm = TRUE) 
     median_depth <- median_depths[chr]
     if (!is.na(median_depth)) {
       prop <- median_depth / max_depth # scale to the bottom plot
@@ -268,31 +282,16 @@ get_plot <- function(snp.data.baf, snp.data.depth, file_name, max_depth, chr_nam
 ####################
 
 # read tsv file into df for BAF plot
-df_vcf <- read_to_df(VCF_FILE)
-write.table(df_vcf, file=paste0(SAMPLE_NAME, ".vcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
+df_vcf <- read_to_df(VCF_FILE, args$max_pop_af)
 
 # read tsv file into df for DEPTH plot
 df_gvcf <- read_to_df(GVCF_FILE)
-write.table(df_gvcf, file=paste0(SAMPLE_NAME, ".gvcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
 
-# DOWNSAMPLE BAF for readability and memory reduction
-# 50,000 points is more than enough to clearly see zygosity without blacking out the plot
-
-set.seed(42)
-
-MAX_PLOT_POINTS <- 50000
-if (nrow(df_vcf) > MAX_PLOT_POINTS) {
-  print(paste("Downsampling BAF data from", nrow(df_vcf), "to", MAX_PLOT_POINTS, "points for plot readability..."))
-  df_vcf <- df_vcf[sample(nrow(df_vcf), MAX_PLOT_POINTS), ]
+if (args$output_tsv) {
+  print("User requested TSVs. Writing raw data before plotting to disk...")
+  write.table(df_vcf, file=paste0(SAMPLE_NAME, ".vcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
+  write.table(df_gvcf, file=paste0(SAMPLE_NAME, ".gvcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
 }
-
-# calculate BAF values and add symmetrical values if required
-if (! (nrow(df_vcf) == 0)) {
-  df_vcf <- calculate_baf(df_vcf, SYMMETRY)
-}
-
-# get quantiles for plotting limits
-MAX_DEPTH <- round(quantile(df_gvcf$Depth, probs = MAX_DEPTH_PCT, names = FALSE), digits = 0)
 
 # Filter out low depth rows for BAF plotting
 df_filtered <- df_vcf[df_vcf$Depth >= MIN_DEPTH, ]
@@ -301,19 +300,39 @@ if (nrow(df_filtered) == 0) {
   df_filtered <- df_vcf
 }
 
+# DOWNSAMPLE BAF for readability and memory reduction
+# 50,000 points is more than enough to clearly see zygosity without blacking out the plot
+
+set.seed(42)
+
+MAX_PLOT_POINTS <- 50000
+if (nrow(df_filtered) > MAX_PLOT_POINTS) {
+  print(paste("Downsampling BAF data from", nrow(df_filtered), "to", MAX_PLOT_POINTS, "points for plot readability..."))
+  df_filtered <- df_filtered[sample(nrow(df_filtered), MAX_PLOT_POINTS), ]
+}
+
+# calculate BAF values and add symmetrical values if required
+if (! (nrow(df_filtered) == 0)) {
+  df_filtered <- calculate_baf(df_filtered, SYMMETRY)
+}
+
+# get quantiles for plotting limits
+MAX_DEPTH <- round(quantile(df_gvcf$Depth, probs = MAX_DEPTH_PCT, names = FALSE), digits = 0)
+
 # dynamic bin size choice
-BIN_SIZE <- ifelse(
-  exists("BIN_SIZE"), BIN_SIZE,
-  ifelse(length(df_gvcf$Depth)/2000 >= 1, round(length(df_gvcf$Depth)/2000), 1)
-)
+if (is.null(BIN_SIZE)) {
+  if ((length(df_gvcf$Depth) / 2000) >= 1) {
+    BIN_SIZE <- round(length(df_gvcf$Depth) / 2000)
+  } else {
+    BIN_SIZE <- 1
+  }
+}
 
 # aggregate gvcf df into binned df for depth plot
 df_binned <- bin_df(df_gvcf, BIN_SIZE)
 snp.data.depth_full <- get_snp_data_Depth(df_binned)
-df_full <- data.frame(x = snp.data.depth_full)
+df_full <- as.data.frame(snp.data.depth_full)
 median_depths <- tapply(df_full$x.mean_depth, df_full$x.seqnames, median, na.rm = TRUE)
-
-write.table(df_binned, file=paste0(SAMPLE_NAME, ".binned.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
 
 # DOWNSAMPLE BINNED DATA for readability and memory reduction
 # 50,000 points is more than enough to clearly see depth distribution without blacking out the plot

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -17,8 +17,6 @@ library(dplyr, quietly = TRUE)
 library(polars, quietly = TRUE)
 library(argparse, quietly = TRUE)
 library(data.table, quietly = TRUE)
-#library(plotly, quietly = TRUE)
-#library(htmlwidgets, quietly = TRUE)
 
 # Get configurable inputs via command line
 ####################################################

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -102,7 +102,7 @@ SYMMETRY <- isTRUE(args$symmetry)
 # Function to read files into dfs
 # @parameter file
 # returns df
-read_to_df <- function(file,max_pop_af = NULL) {
+read_to_df <- function(file) {
   if (!file.exists(file)) {
     stop("File not found: ", file)
   }
@@ -270,7 +270,7 @@ get_plot <- function(snp.data.baf, snp.data.depth, file_name, max_depth, chr_nam
 ####################
 
 # read tsv file into df for BAF plot
-df_vcf <- read_to_df(VCF_FILE, args$max_pop_af)
+df_vcf <- read_to_df(VCF_FILE)
 
 # read tsv file into df for DEPTH plot
 df_gvcf <- read_to_df(GVCF_FILE)

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -286,9 +286,10 @@ if (nrow(df_filtered) == 0) {
 set.seed(42)
 
 MAX_PLOT_POINTS <- 50000
-if (nrow(df_filtered) > MAX_PLOT_POINTS) {
-  print(paste("Downsampling BAF data from", nrow(df_filtered), "to", MAX_PLOT_POINTS, "points for plot readability..."))
-  df_filtered <- df_filtered[sample(nrow(df_filtered), MAX_PLOT_POINTS), ]
+plot_point_cap <- if (isTRUE(SYMMETRY)) MAX_PLOT_POINTS / 2 else MAX_PLOT_POINTS
+if (nrow(df_filtered) > plot_point_cap) {
+  print(paste("Downsampling BAF data from", nrow(df_filtered), "to", plot_point_cap, "points for plot readability..."))
+  df_filtered <- df_filtered[sample(nrow(df_filtered), plot_point_cap), ]
 }
 
 # calculate BAF values and add symmetrical values if required

--- a/src/script.sh
+++ b/src/script.sh
@@ -17,6 +17,9 @@ main() {
     sudo dpkg -i libncurses5_6.2-0ubuntu2_amd64.deb
     sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
 
+    # ADD THIS LINE: Install the missing system ICU library that stringi needs
+    sudo apt-get update && sudo apt-get install -y libicu-dev
+
     tar -xzf $packages_path
     echo "R_LIBS_USER=~/R/library" >> ~/.Renviron
 
@@ -83,11 +86,10 @@ echo "bed_filter_path = $bed_filter_path"
         bcftools index -f -t "$gvcf_path"
     fi
 
-    # Query VCF for CHROM, POS, depth and allele counts
+    # Query VCF for CHROM, POS, depth, allele counts and allele frequency
     bcftools query -r "$vcf_regions" \
-        -f '%CHROM\t%POS\t%INFO/DP\t[ %AD]\n' \
+        -f '%CHROM\t%POS\t%INFO/DP\t[%AD]\t.\n' \
         "$vcf_path" -o "${vcf_prefix}.vcf.tsv"
-
     # Query gVCF with fallback logic FORMAT/DP ->  INFO/DP
     bcftools query -u -r "$gvcf_regions" \
         -f '%CHROM\t%POS\t[%DP]\t%INFO/DP\n' "$gvcf_path" | \
@@ -103,11 +105,17 @@ echo "bed_filter_path = $bed_filter_path"
     options+="--max_baf $max_baf "
     options+="--max_depth $max_depth "
     options+="--min_depth $min_depth "
-    options+="--bin_size $bin_size "
+    if [ -n "$bin_size" ]; then
+        options+="--bin_size $bin_size "
+    fi
     options+="--chr_names $chr_names "
     options+="--genome $genome "
     options+="--symmetry $symmetry "
-
+    if [ "$output_tsv" = true ]; then
+        options+="--output_tsv TRUE "
+    else
+        options+="--output_tsv FALSE "
+    fi
 
     # Run R script with error handling
     if ! Rscript baf_depth_plotting.R --vcf "$vcf_prefix.vcf.tsv" --gvcf "$gvcf_prefix.gvcf.tsv" $options; then

--- a/src/script.sh
+++ b/src/script.sh
@@ -16,8 +16,6 @@ main() {
     sudo dpkg -i libtinfo5_6.2-0ubuntu2_amd64.deb
     sudo dpkg -i libncurses5_6.2-0ubuntu2_amd64.deb
     sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-
-    # ADD THIS LINE: Install the missing system ICU library that stringi needs
     sudo apt-get update && sudo apt-get install -y libicu-dev
 
     tar -xzf $packages_path

--- a/src/script.sh
+++ b/src/script.sh
@@ -84,7 +84,7 @@ echo "bed_filter_path = $bed_filter_path"
         bcftools index -f -t "$gvcf_path"
     fi
 
-    # Query VCF for CHROM, POS, depth, allele counts and allele frequency
+    # Query VCF for CHROM, POS, depth and allele counts
     bcftools query -r "$vcf_regions" \
         -f '%CHROM\t%POS\t%INFO/DP\t[%AD]\n' \
         "$vcf_path" -o "${vcf_prefix}.vcf.tsv"

--- a/src/script.sh
+++ b/src/script.sh
@@ -88,7 +88,7 @@ echo "bed_filter_path = $bed_filter_path"
 
     # Query VCF for CHROM, POS, depth, allele counts and allele frequency
     bcftools query -r "$vcf_regions" \
-        -f '%CHROM\t%POS\t%INFO/DP\t[%AD]\t.\n' \
+        -f '%CHROM\t%POS\t%INFO/DP\t[%AD]\n' \
         "$vcf_path" -o "${vcf_prefix}.vcf.tsv"
     # Query gVCF with fallback logic FORMAT/DP ->  INFO/DP
     bcftools query -u -r "$gvcf_regions" \


### PR DESCRIPTION
Changes in baf_depth_plotting.R:

1. Downsampling & Memory Management
- BAF Downsampling: Caps the BAF plot at 50,000 random points to prevent the script from freezing.
- Depth Downsampling: Caps the Depth plot at 50,000 points, sampling evenly to maintain the genomic distribution.
- Memory Cleanup: Removes Allele_Depth from the BAF data, uses rm() and gc() to clear large dataframes from memory before plotting.
- Faster Parsing: Replaces read.table with data.table::fread for significantly faster file reading.
- Conditional TSVs: Optimises the --output_tsv flag to only write raw files if explicitly requested.

2. Bioinformatics Logic Fixes
- Accurate BAF Calculation: Calculates BAF using only the Reference and Alternate allele counts (Alt / (Ref + Alt)) instead of total depth, preventing skewed ratios from uninformative reads.
- Multi-allelic Handling: The new script splits the Allele_Depth string into 3 parts (str_split_fixed(..., 3)[, 1:2]) instead of 2. This prevents the script from crashing when a variant has multiple alternate alleles (e.g., "40,20,10").
- Rewrote bin_df (dropping the polars dependency) to bin depth by actual DNA distance rather than variant count, preventing exons from distorting the X-axis.
- Crash Fix: Replaced ifelse() with standard if/else logic to fix a fatal crash when the bin size is NULL.

3. Plotting & Aesthetics
- Alpha Transparency: Adds 30% transparency so overlapping points show density instead of solid blobs.
- Reduces point size (cex = 0.2) to make dense plots much easier to read.
- Accurate Medians: Calculates the median depth on the full dataset before downsampling to ensure the plotted median line is statistically true.

Test file project:
project-J9G95904BZX1pxk5fQz191pJ

Job link -1:
https://platform.dnanexus.com/panx/projects/J9G95904BZX1pxk5fQz191pJ/monitor/job/J9QQ6yQ4BZX9534Z1G4VfG3K
Run command:
dx run app-J9QQ6jj4F3Bj81Qy7g3k2BX1 \
-ivcf=file-J8VJV2844qP3JxZ5bF72pQx0 \
-igvcf=file-J8VJV2844qP3pGQk5fVj0k6K \
-imax_depth=0.75 \
-imin_depth=20 \
-imin_baf=0.1 \
-imax_baf=0.9 \
-ipackages=file-GzyV1004y5QX260z2yYyjzbK \
--destination="output/eggd_plot_variant_baf

Job link -2:
https://platform.dnanexus.com/panx/projects/J9G95904BZX1pxk5fQz191pJ/data/output/eggd_plot_variant_baf?&
Run command:
dx run app-J9QQ6jj4F3Bj81Qy7g3k2BX1 \
-ivcf=file-J8VJV2844qP3JxZ5bF72pQx0 \
-igvcf=file-J8VJV2844qP3pGQk5fVj0k6K \
-imax_depth=0.9 \
-imin_depth=20 \
-imin_baf=0.05 \
-imax_baf=0.95 \
-ipackages=file-GzyV1004y5QX260z2yYyjzbK \
-ibin_size=1000 \
-imin_qual=30 \
-ichr_names="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y" \
-ioutput_tsv=true \
--destination="/output/eggd_plot_variant_baf"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_plot_variant_baf/35)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

- **New Features**
  - Added an `output_tsv` option to export extra BAF TSV outputs derived from both VCF and GVCF inputs.
  - Improved plot readability via deterministic downsampling.
- **Bug Fixes**
  - Improved robustness when depth/allele-depth values are missing or zero, preventing unsafe BAF/RAF results.
  - Corrected allele-depth extraction formatting when generating per-site TSVs.
- **Documentation**
  - Expanded `bin_size` and `output_tsv` documentation and added a full command-line example.
- **Chores**
  - Updated installation steps to reduce memory pressure and improve dependency setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->