### PR TITLE
V2.3.0 ram optimisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Plots BAF and depth of variants from given VCF/GVCF pair. The output PNG contain
 - `min_qual` : The minimum QUAL of variants for plotting. Default is 0
 - `chr_names` : Chromosome names used for axis labels and to filter VCF contigs. They must be a subset of the chromosomes in the input VCFs.
 - `output_tsv` : Whether to output a TSV file of the BAF dataframe for testing purposes. Default is False.
-- `max_data_number` : Maximum number of data points to display on the plot. Default is 50000."
+- `max_data_number` : Maximum number of data points to display on the plot. Default is 50000.
 
 **R Packages and Versions:**
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Plots BAF and depth of variants from given VCF/GVCF pair. The output PNG contain
 - `min_qual` : The minimum QUAL of variants for plotting. Default is 0
 - `chr_names` : Chromosome names used for axis labels and to filter VCF contigs. They must be a subset of the chromosomes in the input VCFs.
 - `output_tsv` : Whether to output a TSV file of the BAF dataframe for testing purposes. Default is False.
+- `max_data_number` : Maximum number of data points to display on the plot. Default is 50000."
 
 **R Packages and Versions:**
 
@@ -89,6 +90,7 @@ dx run eggd_plot_variant_baf \
 -imin_depth=20 \
 -isymmetry=true \
 -ibin_size=1000 \
+-imax_data_number=50000 \
 -imax_depth=0.98 \
 -igenome="hg38" \
 -imin_qual=30 \

--- a/dxapp.json
+++ b/dxapp.json
@@ -121,6 +121,14 @@
         "help": "Bin size to use for plotting depth (reduces noise). Default = 500."
       },
       {
+        "name": "max_data_number",
+        "label": "Maximum data points",
+        "class": "int",
+        "default": 50000,
+        "optional": true,
+        "help": "Maximum number of data points to display on the plot. Default is 50000."
+      },
+      {
         "name": "chr_names",
         "label": "Chromosome names",
         "class": "string",

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -60,6 +60,11 @@ if (args$max_depth < 0 || args$max_depth > 1) {
   stop("max_depth must be a percentile value between 0 and 1")
 }
 
+# Validate max data number parameter
+if (is.na(args$max_data_number) || args$max_data_number <= 0) {
+  stop("Error: max_data_number must be a positive integer.")
+}
+
 # get sample name & check they're the same for the two inputs
 SAMPLE_NAME <- str_split_1(sub("\\.vcf\\.tsv$", "", basename(args$vcf)), "_")[1]
 if (SAMPLE_NAME != str_split_1(sub("\\.gvcf\\.tsv$", "", basename(args$gvcf)), "_")[1]) {

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -39,6 +39,8 @@ parser$add_argument("--min_depth", type="integer", default=5,
     help="Minimum depth allowed [default %(default)s]")
 parser$add_argument("--bin_size", type="integer",
     help="Bin size for reducing noise in depth plot")
+parser$add_argument("--max_data_number", type="integer",default=50000,
+    help="Maximum number of data points to display")
 parser$add_argument("--chr_names", type="character", default="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y",
     help="Chromosome names [default %(default)s]")
 parser$add_argument("--genome", type="character", default="hg19",
@@ -47,6 +49,7 @@ parser$add_argument("--symmetry", type="logical", default=TRUE,
     help="Whether to plot BAF symmetrically [default %(default)s]")
 parser$add_argument("--output_tsv", type="logical", default=FALSE,
     help="Whether to write TSV outputs [default %(default)s]")
+
 
 # get command line options, if help option encountered print help and exit,
 # otherwise if options not found on command line then set defaults,
@@ -85,6 +88,10 @@ MIN_DEPTH <- args$min_depth
 
 # Bin size for depth plot
 BIN_SIZE <- args$bin_size
+
+# Data point number for plots display
+MAX_PLOT_POINTS <- args$max_data_number
+MAX_BINNED_POINTS <- args$max_data_number
 
 # Genome build for plotKaryotype function
 GENOME <- args$genome
@@ -287,7 +294,6 @@ if (nrow(df_filtered) == 0) {
 
 set.seed(42)
 
-MAX_PLOT_POINTS <- 50000
 plot_point_cap <- if (isTRUE(SYMMETRY)) MAX_PLOT_POINTS / 2 else MAX_PLOT_POINTS
 if (nrow(df_filtered) > plot_point_cap) {
   print(paste("Downsampling BAF data from", nrow(df_filtered), "to", plot_point_cap, "points for plot readability..."))
@@ -325,7 +331,6 @@ median_depths <- tapply(df$x.mean_depth, df$x.seqnames, median, na.rm = TRUE)
 
 # DOWNSAMPLE BINNED DATA for readability and memory reduction
 # 50,000 points is more than enough to clearly see depth distribution without blacking out the plot
-MAX_BINNED_POINTS <- 50000
 if (nrow(df_binned) > MAX_BINNED_POINTS) {
   print(paste("Downsampling binned depth data from", nrow(df_binned), "to", MAX_BINNED_POINTS, "points for plot readability..."))
   # Use systematic sampling to maintain genomic distribution (taking every Nth row)

--- a/src/script.sh
+++ b/src/script.sh
@@ -106,6 +106,7 @@ echo "bed_filter_path = $bed_filter_path"
     if [ -n "$bin_size" ]; then
         options+="--bin_size $bin_size "
     fi
+    options+="--max_data_number $max_data_number "    
     options+="--chr_names $chr_names "
     options+="--genome $genome "
     options+="--symmetry $symmetry "


### PR DESCRIPTION
Based on Matt's comment, max_data_number was created as a separate configuration. Default 50000; tested successfully.
https://platform.dnanexus.com/panx/projects/J9G95904BZX1pxk5fQz191pJ/monitor/job/J9k0XQ84BZXF6XFqzqQZkGZ3

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_plot_variant_baf/36)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to limit the maximum number of data points displayed in plots.
  * The limit defaults to 50,000 points and applies to both BAF and binned-depth plots.
  * Added the setting to the command-line interface and configuration options.
  * Updated the usage example with the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->