### PR TITLE
V2.3.0 ram optimisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Plots BAF and depth of variants from given VCF/GVCF pair. The output PNG contain
 - `min_qual` : The minimum QUAL of variants for plotting. Default is 0
 - `chr_names` : Chromosome names used for axis labels and to filter VCF contigs. They must be a subset of the chromosomes in the input VCFs.
 - `output_tsv` : Whether to output a TSV file of the BAF dataframe for testing purposes. Default is False.
-- `max_data_number` : Maximum number of data points to display on the plot. Default is 50000.
+- `max_data_number` : Maximum number of data points to display on the plot. Default is 100000.
 
 **R Packages and Versions:**
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Plots BAF and depth of variants from given VCF/GVCF pair. The output PNG contain
 - `genome` : Genome build for plotting. Default is hg19, alternative value is hg38.
 - `min_qual` : The minimum QUAL of variants for plotting. Default is 0
 - `chr_names` : Chromosome names used for axis labels and to filter VCF contigs. They must be a subset of the chromosomes in the input VCFs.
-- `output_tsv` : Whether to output a TSV file of the BAF dataframe for testing purposes. Default is False.
+- `output_tsv` : Whether to output TSV files of the BAF dataframe for testing purposes. Default is False.
 - `max_data_number` : Maximum number of data points to display on the plot. Default is 100000.
 
 **R Packages and Versions:**

--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ This app outputs:
 - `{prefix}.png` : Image of the generated plot in PNG format.
 
 ### If output_tsv is set to True:
-- `{SAMPLE_NAME}.vcf.baf.tsv` : TSV containing the filtered and calculated data from the VCF input before plotting. Includes fields Chr, Position, Ref_AD, Alt_AD, RAF, BAF.
+- `{SAMPLE_NAME}.vcf.baf.tsv` : TSV containing the raw data from the VCF input. Includes fields Chr, Position, Depth, Allele_Depth.
 - `{SAMPLE_NAME}.gvcf.baf.tsv` : TSV containing the raw data from the GVCF input. Includes fields Chr, Position, Depth.
+- `{SAMPLE_NAME}.filtered.baf.tsv` : TSV containing the filtered and calculated data from the VCF input before plotting. Includes fields Chr, Position, Depth, Ref_AD, Alt_AD, RAF, BAF.
+- `{SAMPLE_NAME}.binned.baf.tsv` : TSV containing the binned and calculated data from the GVCF input before plotting. Includes fields Chr, Position, mean_depth.
 
 
 ## How to run this app from command line?

--- a/dxapp.json
+++ b/dxapp.json
@@ -126,7 +126,7 @@
         "class": "int",
         "default": 50000,
         "optional": true,
-        "help": "Maximum number of data points to display on the plot. Default is 50000."
+        "help": "Maximum number of data points to display on the plot. Default is 100000."
       },
       {
         "name": "chr_names",

--- a/dxapp.json
+++ b/dxapp.json
@@ -124,7 +124,7 @@
         "name": "max_data_number",
         "label": "Maximum data points",
         "class": "int",
-        "default": 50000,
+        "default": 100000,
         "optional": true,
         "help": "Maximum number of data points to display on the plot. Default is 100000."
       },

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -288,7 +288,7 @@ df_vcf <- read_to_df(VCF_FILE)
 df_gvcf <- read_to_df(GVCF_FILE)
 
 if (args$output_tsv) {
-  print("User requested TSVs. Writing calculated data before plotting to disk...")
+  print("User requested TSVs. Writing raw data before filtration...")
   write.table(df_vcf, file=paste0(SAMPLE_NAME, ".vcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
   write.table(df_gvcf, file=paste0(SAMPLE_NAME, ".gvcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
 }

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -39,7 +39,7 @@ parser$add_argument("--min_depth", type="integer", default=5,
     help="Minimum depth allowed [default %(default)s]")
 parser$add_argument("--bin_size", type="integer",
     help="Bin size for reducing noise in depth plot")
-parser$add_argument("--max_data_number", type="integer",default=50000,
+parser$add_argument("--max_data_number", type="integer",default=100000,
     help="Maximum number of data points to display")
 parser$add_argument("--chr_names", type="character", default="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y",
     help="Chromosome names [default %(default)s]")

--- a/resources/home/dnanexus/baf_depth_plotting.R
+++ b/resources/home/dnanexus/baf_depth_plotting.R
@@ -287,6 +287,12 @@ df_vcf <- read_to_df(VCF_FILE)
 # read tsv file into df for DEPTH plot
 df_gvcf <- read_to_df(GVCF_FILE)
 
+if (args$output_tsv) {
+  print("User requested TSVs. Writing calculated data before plotting to disk...")
+  write.table(df_vcf, file=paste0(SAMPLE_NAME, ".vcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
+  write.table(df_gvcf, file=paste0(SAMPLE_NAME, ".gvcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
+}
+
 # Filter out low depth rows for BAF plotting
 df_filtered <- df_vcf[df_vcf$Depth >= MIN_DEPTH, ]
 if (nrow(df_filtered) == 0) {
@@ -308,12 +314,6 @@ if (nrow(df_filtered) > plot_point_cap) {
 # calculate BAF values and add symmetrical values if required
 if (! (nrow(df_filtered) == 0)) {
   df_filtered <- calculate_baf(df_filtered, SYMMETRY)
-}
-
-if (args$output_tsv) {
-  print("User requested TSVs. Writing calculated data before plotting to disk...")
-  write.table(df_filtered, file=paste0(SAMPLE_NAME, ".vcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
-  write.table(df_gvcf, file=paste0(SAMPLE_NAME, ".gvcf.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
 }
 
 # get quantiles for plotting limits
@@ -341,6 +341,12 @@ if (nrow(df_binned) > MAX_BINNED_POINTS) {
   # Use systematic sampling to maintain genomic distribution (taking every Nth row)
   step_size <- ceiling(nrow(df_binned) / MAX_BINNED_POINTS)
   df_binned <- df_binned[seq(1, nrow(df_binned), by = step_size), ]
+}
+
+if (args$output_tsv) {
+  print("User requested TSVs. Writing calculated data before plotting to disk...")
+  write.table(df_filtered, file=paste0(SAMPLE_NAME, ".filtered.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
+  write.table(df_binned, file=paste0(SAMPLE_NAME, ".binned.baf.tsv"), quote=FALSE, sep='\t', col.names = NA)
 }
 
 # MEMORY CLEAR: Removed massive intermediate write.tables here.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_plot_variant_baf/37)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the default plotting data limit to 100,000 points, enabling larger datasets to be visualised.
  * Added binned GVCF TSV output documentation.
* **Improvements**
  * Clarified TSV outputs for raw and filtered VCF data.
  * Raw VCF exports now include depth and allele-depth values.
  * Filtered VCF exports document calculated RAF and BAF values.
  * Retained documentation for raw GVCF output and improved output sequencing for processed BAF and depth data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->